### PR TITLE
Fixes for a working set of components

### DIFF
--- a/Code/Include/ROS2/ROS2Bus.h
+++ b/Code/Include/ROS2/ROS2Bus.h
@@ -11,6 +11,7 @@
 #include <AzCore/Interface/Interface.h>
 #include <rclcpp/node.hpp>
 #include <builtin_interfaces/msg/time.hpp>
+#include <geometry_msgs/msg/transform_stamped.hpp>
 
 namespace ROS2
 {
@@ -23,6 +24,7 @@ namespace ROS2
         // Put your public methods here
         virtual std::shared_ptr<rclcpp::Node> GetNode() const = 0;
         virtual builtin_interfaces::msg::Time GetROSTimestamp() const = 0;
+        virtual void BroadcastStaticTransform(const geometry_msgs::msg::TransformStamped& t) const = 0;
     };
     
     class ROS2BusTraits

--- a/Code/Source/Lidar/ROS2LidarSensorComponent.cpp
+++ b/Code/Source/Lidar/ROS2LidarSensorComponent.cpp
@@ -28,7 +28,7 @@ namespace ROS2
 
             if (AZ::EditContext* ec = serialize->GetEditContext())
             {
-                ec->Class<ROS2LidarSensorComponent>("Lidar Sensor", "[Simple Lidar component]")
+                ec->Class<ROS2LidarSensorComponent>("ROS2 Lidar Sensor", "[Simple Lidar component]")
                     ->ClassElement(AZ::Edit::ClassElements::EditorData, "")
                         ->Attribute(AZ::Edit::Attributes::AppearsInAddComponentMenu, AZ_CRC("Game"))
                     ->DataElement(AZ::Edit::UIHandlers::Default, &ROS2LidarSensorComponent::m_lidarModel, "Lidar Model", "Lidar model")

--- a/Code/Source/Lidar/ROS2LidarSensorComponent.cpp
+++ b/Code/Source/Lidar/ROS2LidarSensorComponent.cpp
@@ -30,7 +30,7 @@ namespace ROS2
             {
                 ec->Class<ROS2LidarSensorComponent>("Lidar Sensor", "[Simple Lidar component]")
                     ->ClassElement(AZ::Edit::ClassElements::EditorData, "")
-                        ->Attribute(AZ::Edit::Attributes::AppearsInAddComponentMenu, AZ_CRC("Simulation"))
+                        ->Attribute(AZ::Edit::Attributes::AppearsInAddComponentMenu, AZ_CRC("Game"))
                     ->DataElement(AZ::Edit::UIHandlers::Default, &ROS2LidarSensorComponent::m_lidarModel, "Lidar Model", "Lidar model")
                     ;
             }

--- a/Code/Source/ROS2ModuleInterface.h
+++ b/Code/Source/ROS2ModuleInterface.h
@@ -10,6 +10,7 @@
 #include <ROS2SystemComponent.h>
 #include <Lidar/ROS2LidarSensorComponent.h>
 #include <RobotControl/ROS2RobotControlComponent.h>
+#include <Transform/ROS2FrameComponent.h>
 
 namespace ROS2
 {
@@ -24,12 +25,14 @@ namespace ROS2
         {
             // Push results of [MyComponent]::CreateDescriptor() into m_descriptors here.
             // Add ALL components descriptors associated with this gem to m_descriptors.
-            // This will associate the AzTypeInfo information for the components with the the SerializeContext, BehaviorContext and EditContext.
+            // This will associate the AzTypeInfo information for the components with the SerializeContext, BehaviorContext and EditContext.
             // This happens through the [MyComponent]::Reflect() function.
             m_descriptors.insert(m_descriptors.end(), {
                 ROS2SystemComponent::CreateDescriptor(),
+                ROS2SensorComponent::CreateDescriptor(),
                 ROS2LidarSensorComponent::CreateDescriptor(),
                 ROS2RobotControlComponent::CreateDescriptor(),
+                ROS2FrameComponent::CreateDescriptor()
                 });
         }
 

--- a/Code/Source/ROS2SystemComponent.cpp
+++ b/Code/Source/ROS2SystemComponent.cpp
@@ -25,7 +25,7 @@ namespace ROS2
 
             if (AZ::EditContext* ec = serialize->GetEditContext())
             {
-                ec->Class<ROS2SystemComponent>("ROS2", "[Description of functionality provided by this System Component]")
+                ec->Class<ROS2SystemComponent>("ROS2 System Component", "[Description of functionality provided by this System Component]")
                     ->ClassElement(AZ::Edit::ClassElements::EditorData, "")
                         ->Attribute(AZ::Edit::Attributes::AppearsInAddComponentMenu, AZ_CRC("System"))
                         ->Attribute(AZ::Edit::Attributes::AutoExpand, true)

--- a/Code/Source/ROS2SystemComponent.cpp
+++ b/Code/Source/ROS2SystemComponent.cpp
@@ -79,6 +79,8 @@ namespace ROS2
 
     void ROS2SystemComponent::Activate()
     {
+        m_staticTFBroadcaster = AZStd::make_unique<tf2_ros::StaticTransformBroadcaster>(m_ros2Node);
+
         ROS2RequestBus::Handler::BusConnect();
         AZ::TickBus::Handler::BusConnect();
     }
@@ -87,6 +89,8 @@ namespace ROS2
     {
         AZ::TickBus::Handler::BusDisconnect();
         ROS2RequestBus::Handler::BusDisconnect();
+
+        m_staticTFBroadcaster.reset();
     }
 
     builtin_interfaces::msg::Time ROS2SystemComponent::GetROSTimestamp() const
@@ -97,6 +101,11 @@ namespace ROS2
     std::shared_ptr<rclcpp::Node> ROS2SystemComponent::GetNode() const
     {
         return m_ros2Node;
+    }
+
+    void ROS2SystemComponent::BroadcastStaticTransform(const geometry_msgs::msg::TransformStamped& t) const
+    {
+        m_staticTFBroadcaster->sendTransform(t);
     }
 
     void ROS2SystemComponent::OnTick([[maybe_unused]] float deltaTime, [[maybe_unused]] AZ::ScriptTimePoint time)

--- a/Code/Source/ROS2SystemComponent.h
+++ b/Code/Source/ROS2SystemComponent.h
@@ -9,11 +9,14 @@
 
 #include <AzCore/Component/Component.h>
 #include <AzCore/Component/TickBus.h>
+#include <AzCore/std/smart_ptr/unique_ptr.h>
 #include <ROS2/ROS2Bus.h>
 
 #include <memory>
 #include "rclcpp/rclcpp.hpp"
 #include "builtin_interfaces/msg/time.hpp"
+#include <tf2_ros/static_transform_broadcaster.h>
+
 #include "Clock/SimulationClock.h"
 
 namespace ROS2
@@ -39,6 +42,9 @@ namespace ROS2
         std::shared_ptr<rclcpp::Node> GetNode() const override;
         builtin_interfaces::msg::Time GetROSTimestamp() const override;
 
+        // TODO - rethink ownership of this one. It needs to be a singleton-like behavior, but not necessarily here
+        void BroadcastStaticTransform(const geometry_msgs::msg::TransformStamped& t) const override;
+
     protected:
         ////////////////////////////////////////////////////////////////////////
         // ROS2RequestBus interface implementation
@@ -60,6 +66,7 @@ namespace ROS2
     private:
         std::shared_ptr<rclcpp::Node> m_ros2Node;
         AZStd::shared_ptr<rclcpp::executors::SingleThreadedExecutor> m_executor;
+        AZStd::unique_ptr<tf2_ros::StaticTransformBroadcaster> m_staticTFBroadcaster;
         SimulationClock m_simulationClock;
     };
 

--- a/Code/Source/RobotControl/ROS2RobotControlComponent.cpp
+++ b/Code/Source/RobotControl/ROS2RobotControlComponent.cpp
@@ -44,7 +44,7 @@ namespace ROS2
 
             if (AZ::EditContext* ec = serialize->GetEditContext())
             {
-                ec->Class<ROS2RobotControlComponent>("Robot control", "[Customizable robot control component]")
+                ec->Class<ROS2RobotControlComponent>("ROS2 Robot control", "[Customizable robot control component]")
                     ->ClassElement(AZ::Edit::ClassElements::EditorData, "")
                         ->Attribute(AZ::Edit::Attributes::AppearsInAddComponentMenu, AZ_CRC("Game")) // TODO - "Simulation"?
                     ->DataElement(AZ::Edit::UIHandlers::Default, &ROS2RobotControlComponent::m_topic, "Topic", "ROS2 topic to subscribe to")

--- a/Code/Source/Sensor/ROS2SensorComponent.cpp
+++ b/Code/Source/Sensor/ROS2SensorComponent.cpp
@@ -36,7 +36,7 @@ namespace ROS2
 
             if (AZ::EditContext* ec = serialize->GetEditContext())
             {
-                ec->Class<ROS2SensorComponent>("ROS2 Sensor Component", "[Base component for sensors]")
+                ec->Class<ROS2SensorComponent>("ROS2 Sensor", "[Base component for sensors]")
                         ->ClassElement(AZ::Edit::ClassElements::EditorData, "")
                             ->Attribute(AZ::Edit::Attributes::AppearsInAddComponentMenu, AZ_CRC("Game"))
                         ->DataElement(AZ::Edit::UIHandlers::Default, &ROS2SensorComponent::m_sensorConfiguration, "Sensor configuration", "Sensor configuration")

--- a/Code/Source/Sensor/ROS2SensorComponent.cpp
+++ b/Code/Source/Sensor/ROS2SensorComponent.cpp
@@ -26,12 +26,22 @@ namespace ROS2
 
     void ROS2SensorComponent::Reflect(AZ::ReflectContext* context)
     {
+        SensorConfiguration::Reflect(context);
         if (AZ::SerializeContext* serialize = azrtti_cast<AZ::SerializeContext*>(context))
         {
             serialize->Class<ROS2SensorComponent, AZ::Component>()
                 ->Version(1)
                 ->Field("SensorConfiguration", &ROS2SensorComponent::m_sensorConfiguration)
                 ;
+
+            if (AZ::EditContext* ec = serialize->GetEditContext())
+            {
+                ec->Class<ROS2SensorComponent>("ROS2 Sensor Component", "[Base component for sensors]")
+                        ->ClassElement(AZ::Edit::ClassElements::EditorData, "")
+                            ->Attribute(AZ::Edit::Attributes::AppearsInAddComponentMenu, AZ_CRC("Game"))
+                        ->DataElement(AZ::Edit::UIHandlers::Default, &ROS2SensorComponent::m_sensorConfiguration, "Sensor configuration", "Sensor configuration")
+                        ;
+            }
         }
     }
 

--- a/Code/Source/Sensor/SensorConfiguration.cpp
+++ b/Code/Source/Sensor/SensorConfiguration.cpp
@@ -23,6 +23,16 @@ namespace ROS2
                 ->Field("Frequency (HZ)", &SensorConfiguration::m_frequency)
                 ->Field("Visualise", &SensorConfiguration::m_visualise)
                 ;
+
+            if (AZ::EditContext* ec = serialize->GetEditContext())
+            {
+                ec->Class<SensorConfiguration>("ROS2 Sensor Component", "[Base component for sensors]")
+                        ->DataElement(AZ::Edit::UIHandlers::Default, &SensorConfiguration::m_topic, "Topic", "Topic")
+                        ->DataElement(AZ::Edit::UIHandlers::Default, &SensorConfiguration::m_publishingEnabled, "Publishing Enabled", "Publishing Enabled")
+                        ->DataElement(AZ::Edit::UIHandlers::Default, &SensorConfiguration::m_frequency, "Frequency", "Frequency (HZ)")
+                        ->DataElement(AZ::Edit::UIHandlers::Default, &SensorConfiguration::m_visualise, "Visualise", "Visualise")
+                        ;
+            }
         }
     }
 }  // namespace ROS2

--- a/Code/Source/Sensor/SensorConfiguration.h
+++ b/Code/Source/Sensor/SensorConfiguration.h
@@ -25,7 +25,7 @@ namespace ROS2
         static void Reflect(AZ::ReflectContext* context);
 
         // TODO - publishing-related data
-        AZStd::string m_topic; // TODO - apply namespace, default to standard names per type, validation
+        AZStd::string m_topic = "default_topic"; // TODO - apply namespace, default to standard names per type, validation
         bool m_publishingEnabled = true; // TODO - support this flag
         float m_frequency = 10;
         // TODO - add QoS here (struct, mapped to ros2 QoS).

--- a/Code/Source/Transform/ROS2FrameComponent.cpp
+++ b/Code/Source/Transform/ROS2FrameComponent.cpp
@@ -6,8 +6,11 @@
  *
  */
 #include "ROS2/ROS2Bus.h"
+#include "Transform/ROS2FrameComponent.h"
 #include "Utilities/ROS2Names.h"
 #include <AzCore/Component/Entity.h>
+#include <AzCore/Serialization/EditContext.h>
+#include <AzCore/Serialization/EditContextConstants.inl>
 #include <AzCore/Serialization/SerializeContext.h>
 
 namespace ROS2
@@ -77,6 +80,16 @@ namespace ROS2
                 ->Field("Namespace", &ROS2FrameComponent::m_namespace)
                 ->Field("Frame Name", &ROS2FrameComponent::m_frameName)
                 ;
+
+            if (AZ::EditContext* ec = serialize->GetEditContext())
+            {
+                ec->Class<ROS2FrameComponent>("ROS2 Frame Component", "[ROS2 Frame component]")
+                        ->ClassElement(AZ::Edit::ClassElements::EditorData, "")
+                            ->Attribute(AZ::Edit::Attributes::AppearsInAddComponentMenu, AZ_CRC("Game"))
+                        ->DataElement(AZ::Edit::UIHandlers::Default, &ROS2FrameComponent::m_namespace, "Namespace", "Namespace")
+                        ->DataElement(AZ::Edit::UIHandlers::Default, &ROS2FrameComponent::m_frameName, "Frame Name", "Frame Name")
+                        ;
+            }
         }
     }
 

--- a/Code/Source/Transform/ROS2FrameComponent.cpp
+++ b/Code/Source/Transform/ROS2FrameComponent.cpp
@@ -83,7 +83,7 @@ namespace ROS2
 
             if (AZ::EditContext* ec = serialize->GetEditContext())
             {
-                ec->Class<ROS2FrameComponent>("ROS2 Frame Component", "[ROS2 Frame component]")
+                ec->Class<ROS2FrameComponent>("ROS2 Frame", "[ROS2 Frame component]")
                         ->ClassElement(AZ::Edit::ClassElements::EditorData, "")
                             ->Attribute(AZ::Edit::Attributes::AppearsInAddComponentMenu, AZ_CRC("Game"))
                         ->DataElement(AZ::Edit::UIHandlers::Default, &ROS2FrameComponent::m_namespace, "Namespace", "Namespace")

--- a/Code/Source/Transform/ROS2FrameComponent.h
+++ b/Code/Source/Transform/ROS2FrameComponent.h
@@ -10,6 +10,7 @@
 #include "TransformPublisher.h"
 #include <AzCore/Component/Component.h>
 #include <AzCore/std/smart_ptr/unique_ptr.h>
+#include <AzFramework/Components/TransformComponent.h>
 
 namespace ROS2
 {
@@ -20,7 +21,7 @@ namespace ROS2
         : public AZ::Component
     {
     public:
-        AZ_COMPONENT(ROS2SensorComponent, "{EE743472-3E25-41EA-961B-14096AC1D66F}", AZ::Component);
+        AZ_COMPONENT(ROS2FrameComponent, "{EE743472-3E25-41EA-961B-14096AC1D66F}", AZ::Component);
 
         void Activate() override;
         void Deactivate() override;

--- a/Code/Source/Transform/TransformPublisher.cpp
+++ b/Code/Source/Transform/TransformPublisher.cpp
@@ -9,23 +9,21 @@
 #include "Transform/TransformPublisher.h"
 #include "ROS2/ROS2Bus.h"
 #include "Utilities/ROS2Conversions.h"
-#include <geometry_msgs/msg/transform_stamped.hpp>
 
 namespace ROS2
 {
     TransformPublisher::TransformPublisher(
         const AZStd::string& parentFrame, const AZStd::string& childFrame, const AZ::Transform& o3deTransform)
     {
-        auto ros2Node = ROS2Interface::Get()->GetNode();
-        m_staticTFPublisher = AZStd::make_unique<tf2_ros::StaticTransformBroadcaster>(ros2Node);
 
         geometry_msgs::msg::TransformStamped t;
-
         t.header.stamp = ROS2Interface::Get()->GetROSTimestamp();
         t.header.frame_id = parentFrame.data();
         t.child_frame_id = childFrame.data();
         t.transform.translation = ROS2Conversions::ToROS2Vector3(o3deTransform.GetTranslation());
         t.transform.rotation = ROS2Conversions::ToROS2Quaternion(o3deTransform.GetRotation());
-        m_staticTFPublisher->sendTransform(t);
+
+        // TODO - if static
+        ROS2Interface::Get()->BroadcastStaticTransform(t);
     }
 }  // namespace ROS2

--- a/Code/Source/Transform/TransformPublisher.h
+++ b/Code/Source/Transform/TransformPublisher.h
@@ -9,20 +9,15 @@
 
 #include <AzCore/Math/Transform.h>
 #include <AzCore/std/string/string.h>
-#include <AzCore/std/smart_ptr/unique_ptr.h>
-#include <tf2_ros/static_transform_broadcaster.h>
 
 namespace ROS2
 {
    /// Publishes transforms as standard ros2 tf2 messages. Static transforms are published once.
-   // TODO - differentiate between static and dynamic publisher
+   // TODO - differentiate between static and dynamic publisher. Rework this class (name, function)
    class TransformPublisher
    {
    public:
        TransformPublisher(const AZStd::string& parentFrame, const AZStd::string &childFrame,
                           const AZ::Transform& transform);
-
-   private:
-       AZStd::unique_ptr<tf2_ros::StaticTransformBroadcaster> m_staticTFPublisher;
    };
 }  // namespace ROS2


### PR DESCRIPTION
Changes required for Components to work correctly:
- display in search
- have editable fields

Static transform broadcaster needs to be a singleton - it has been moved to system component. However, TransformPublisher remains and will be responsible for dynamic transforms (which will reuse the same message creation code).

Signed-off-by: Adam Dabrowski <adam.dabrowski@robotec.ai>