### PR TITLE
ROS2 Sensor abstraction

### DIFF
--- a/Code/Source/Clock/SimulationClock.cpp
+++ b/Code/Source/Clock/SimulationClock.cpp
@@ -5,8 +5,9 @@
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *
  */
+
 #include "SimulationClock.h"
-#include <ROS2/ROS2Bus.h>
+#include "ROS2/ROS2Bus.h"
 #include <rclcpp/qos.hpp>
 
 namespace ROS2
@@ -40,9 +41,7 @@ namespace ROS2
         {   //Lazy construct
             auto ros2Node = ROS2Interface::Get()->GetNode();
 
-            // Standard QoS for /clock topic is best_effort, keep_last 1
-            rclcpp::QoS qos(1);
-            qos.best_effort();
+            rclcpp::ClockQoS qos;
             m_clockPublisher = ros2Node->create_publisher<rosgraph_msgs::msg::Clock>("/clock", qos);
         }
 

--- a/Code/Source/Frame/NamespaceConfiguration.h
+++ b/Code/Source/Frame/NamespaceConfiguration.h
@@ -18,9 +18,7 @@ namespace ROS2
     struct NamespaceConfiguration
     {
     public:
-        AZ_RTTI(NamespaceConfiguration, "{5E5BC6EA-DD01-480E-A4D1-6857CF70FDC8}");
-        NamespaceConfiguration() = default;
-        virtual ~NamespaceConfiguration() = default;
+        AZ_TYPE_INFO(NamespaceConfiguration, "{5E5BC6EA-DD01-480E-A4D1-6857CF70FDC8}");
         static void Reflect(AZ::ReflectContext* context);
 
         enum NamespaceStrategy

--- a/Code/Source/QoS/QoS.cpp
+++ b/Code/Source/QoS/QoS.cpp
@@ -1,0 +1,66 @@
+/*
+* Copyright (c) Contributors to the Open 3D Engine Project.
+* For complete copyright and license terms please see the LICENSE at the root of this distribution.
+*
+* SPDX-License-Identifier: Apache-2.0 OR MIT
+*
+*/
+
+#pragma once
+
+#include "QoS.h"
+#include <AzCore/Serialization/EditContext.h>
+#include <AzCore/Serialization/SerializeContext.h>
+
+namespace ROS2
+{
+    QoS::QoS(const rclcpp::QoS& qos)
+    {
+        m_reliabilityPolicy = qos.reliability();
+        m_durabilityPolicy = qos.durability();
+        m_depth = qos.depth();
+    }
+
+    AZ::Crc32 QoS::OnQoSSelected()
+    {
+        return AZ::Edit::PropertyRefreshLevels::AttributesAndValues;
+    }
+
+    rclcpp::QoS QoS::GetQoS() const
+    {
+        rclcpp::QoS qos(m_depth);
+        return qos.reliability(m_reliabilityPolicy).durability(m_durabilityPolicy);
+    }
+
+    void QoS::Reflect(AZ::ReflectContext* context)
+    {
+        if (auto serializeContext = azrtti_cast<AZ::SerializeContext*>(context))
+        {
+            serializeContext->Class<QoS>()
+                ->Version(1)
+                ->Field("Reliability", &QoS::m_reliabilityPolicy)
+                ->Field("Durability", &QoS::m_durabilityPolicy)
+                ->Field("Depth", &QoS::m_depth)
+                ;
+
+            if (AZ::EditContext* ec = serializeContext->GetEditContext())
+            {
+                ec->Class<QoS>("Quality of Service configuration", "")
+                    ->ClassElement(AZ::Edit::ClassElements::EditorData, "")
+                        ->DataElement(AZ::Edit::UIHandlers::ComboBox, &QoS::m_reliabilityPolicy,
+                                      "Reliability policy", "Determines DDS reliability policy for the publisher")
+                            ->Attribute(AZ::Edit::Attributes::ChangeNotify, &QoS::OnQoSSelected)
+                            ->EnumAttribute(rclcpp::ReliabilityPolicy::Reliable, "Reliable")
+                            ->EnumAttribute(rclcpp::ReliabilityPolicy::BestEffort, "Best Effort")
+                        ->DataElement(AZ::Edit::UIHandlers::ComboBox, &QoS::m_durabilityPolicy,
+                                      "Durability policy", "Determines DDS durability policy for the publisher")
+                            ->Attribute(AZ::Edit::Attributes::ChangeNotify, &QoS::OnQoSSelected)
+                            ->EnumAttribute(rclcpp::DurabilityPolicy::Volatile, "Volatile")
+                            ->EnumAttribute(rclcpp::DurabilityPolicy::TransientLocal, "Transient Local")
+                        ->DataElement(AZ::Edit::UIHandlers::Default, &QoS::m_depth, "History depth", "Determines DDS publisher queue size")
+                        ;
+            }
+        }
+    };
+}  // namespace ROS2
+

--- a/Code/Source/QoS/QoS.h
+++ b/Code/Source/QoS/QoS.h
@@ -1,0 +1,36 @@
+/*
+* Copyright (c) Contributors to the Open 3D Engine Project.
+* For complete copyright and license terms please see the LICENSE at the root of this distribution.
+*
+* SPDX-License-Identifier: Apache-2.0 OR MIT
+*
+*/
+
+#pragma once
+
+#include <AzCore/RTTI/RTTI.h>
+#include <AzCore/Serialization/SerializeContext.h>
+#include <rclcpp/qos.hpp>
+
+namespace ROS2
+{
+    /// A wrapper on rclcpp::QoS (Quality of Service for DDS) with reflection
+    struct QoS
+    {
+    public:
+        AZ_RTTI(QoS, "{46692EA4-EA4C-495E-AD3C-426EAB8954D3}");
+        QoS(const rclcpp::QoS& qos = rclcpp::QoS(rmw_qos_profile_default.depth));
+        virtual ~QoS() = default;
+        static void Reflect(AZ::ReflectContext* context);
+        rclcpp::QoS GetQoS() const;
+
+    private:
+        AZ::Crc32 OnQoSSelected();
+
+        // TODO - only for Editor component
+        // Can be extended to also expose history and liveliness
+        rclcpp::ReliabilityPolicy m_reliabilityPolicy;
+        rclcpp::DurabilityPolicy m_durabilityPolicy;
+        uint32_t m_depth;
+    };
+}  // namespace ROS2

--- a/Code/Source/QoS/QoS.h
+++ b/Code/Source/QoS/QoS.h
@@ -18,9 +18,8 @@ namespace ROS2
     struct QoS
     {
     public:
-        AZ_RTTI(QoS, "{46692EA4-EA4C-495E-AD3C-426EAB8954D3}");
+        AZ_TYPE_INFO(QoS, "{46692EA4-EA4C-495E-AD3C-426EAB8954D3}");
         QoS(const rclcpp::QoS& qos = rclcpp::QoS(rmw_qos_profile_default.depth));
-        virtual ~QoS() = default;
         static void Reflect(AZ::ReflectContext* context);
         rclcpp::QoS GetQoS() const;
 

--- a/Code/Source/ROS2ModuleInterface.h
+++ b/Code/Source/ROS2ModuleInterface.h
@@ -8,6 +8,7 @@
 #include <AzCore/Memory/SystemAllocator.h>
 #include <AzCore/Module/Module.h>
 #include <Frame/ROS2FrameComponent.h>
+#include <Sensor/ROS2SensorComponent.h>
 #include <ROS2SystemComponent.h>
 
 namespace ROS2
@@ -23,10 +24,11 @@ namespace ROS2
         {
             // Push results of [MyComponent]::CreateDescriptor() into m_descriptors here.
             // Add ALL components descriptors associated with this gem to m_descriptors.
-            // This will associate the AzTypeInfo information for the components with the the SerializeContext, BehaviorContext and EditContext.
+            // This will associate the AzTypeInfo information for the components with the SerializeContext, BehaviorContext and EditContext.
             // This happens through the [MyComponent]::Reflect() function.
             m_descriptors.insert(m_descriptors.end(), {
                 ROS2SystemComponent::CreateDescriptor(),
+                ROS2SensorComponent::CreateDescriptor(),
                 ROS2FrameComponent::CreateDescriptor()
                 });
         }

--- a/Code/Source/Sensor/PublisherConfiguration.cpp
+++ b/Code/Source/Sensor/PublisherConfiguration.cpp
@@ -1,0 +1,43 @@
+/*
+* Copyright (c) Contributors to the Open 3D Engine Project.
+* For complete copyright and license terms please see the LICENSE at the root of this distribution.
+*
+* SPDX-License-Identifier: Apache-2.0 OR MIT
+*
+*/
+
+#pragma once
+
+#include "PublisherConfiguration.h"
+#include <AzCore/Serialization/EditContext.h>
+#include <AzCore/Serialization/SerializeContext.h>
+
+namespace ROS2
+{
+    /// A struct used to create and configure publishers
+    void PublisherConfiguration::Reflect(AZ::ReflectContext* context)
+    {
+        QoS::Reflect(context);
+        if (auto serializeContext = azrtti_cast<AZ::SerializeContext*>(context))
+        {
+            serializeContext->Class<PublisherConfiguration>()
+                ->Version(1)
+                ->Field("Type", &PublisherConfiguration::m_type)
+                ->Field("Topic", &PublisherConfiguration::m_topic)
+                ->Field("QoS", &PublisherConfiguration::m_qos)
+                ;
+
+            if (AZ::EditContext* ec = serializeContext->GetEditContext())
+            {
+                ec->Class<PublisherConfiguration>("Publisher configuration", "")
+                    ->ClassElement(AZ::Edit::ClassElements::EditorData, "")
+                    ->DataElement(AZ::Edit::UIHandlers::Default, &PublisherConfiguration::m_type, "Type", "Type of topic messages")
+                        ->Attribute(AZ::Edit::Attributes::ReadOnly, true)
+                    ->DataElement(AZ::Edit::UIHandlers::Default, &PublisherConfiguration::m_topic, "Topic", "Topic with no namespace")
+                    ->DataElement(AZ::Edit::UIHandlers::Default, &PublisherConfiguration::m_qos, "QoS", "Quality of Service")
+                    ;
+            }
+        }
+    };
+}  // namespace ROS2
+

--- a/Code/Source/Sensor/PublisherConfiguration.h
+++ b/Code/Source/Sensor/PublisherConfiguration.h
@@ -19,9 +19,7 @@ namespace ROS2
     struct PublisherConfiguration
     {
     public:
-        AZ_RTTI(PublisherConfiguration, "{7F875348-F2F9-404A-841E-D9A749EA4E79}");
-        PublisherConfiguration() = default;
-        virtual ~PublisherConfiguration() = default;
+        AZ_TYPE_INFO(PublisherConfiguration, "{7F875348-F2F9-404A-841E-D9A749EA4E79}");
         static void Reflect(AZ::ReflectContext* context);
 
         bool operator==(const PublisherConfiguration& other) const

--- a/Code/Source/Sensor/PublisherConfiguration.h
+++ b/Code/Source/Sensor/PublisherConfiguration.h
@@ -1,0 +1,46 @@
+/*
+* Copyright (c) Contributors to the Open 3D Engine Project.
+* For complete copyright and license terms please see the LICENSE at the root of this distribution.
+*
+* SPDX-License-Identifier: Apache-2.0 OR MIT
+*
+*/
+
+#pragma once
+
+#include <AzCore/RTTI/RTTI.h>
+#include <AzCore/Serialization/SerializeContext.h>
+#include <AzCore/std/string/string.h>
+#include "QoS/QoS.h"
+
+namespace ROS2
+{
+    /// A struct used to create and configure publishers
+    struct PublisherConfiguration
+    {
+    public:
+        AZ_RTTI(PublisherConfiguration, "{7F875348-F2F9-404A-841E-D9A749EA4E79}");
+        PublisherConfiguration() = default;
+        virtual ~PublisherConfiguration() = default;
+        static void Reflect(AZ::ReflectContext* context);
+
+        bool operator==(const PublisherConfiguration& other) const
+        {
+            if (m_type != other.m_type)
+            {
+                return false;
+            }
+
+            return m_topic == other.m_topic;
+        }
+
+        AZStd::string m_type = "std_msgs::msg::Empty";
+        AZStd::string m_topic = "default_topic";
+
+        rclcpp::QoS GetQoS() const { return m_qos.GetQoS(); }
+
+    private:
+        QoS m_qos = rclcpp::SensorDataQoS();
+    };
+}  // namespace ROS2
+

--- a/Code/Source/Sensor/ROS2SensorComponent.cpp
+++ b/Code/Source/Sensor/ROS2SensorComponent.cpp
@@ -1,0 +1,94 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#include "Frame/ROS2FrameComponent.h"
+#include "Sensor/ROS2SensorComponent.h"
+#include "ROS2/ROS2Bus.h"
+#include "Utilities/ROS2Names.h"
+
+#include <AzCore/Component/Entity.h>
+#include <AzCore/Serialization/EditContext.h>
+#include <AzCore/Serialization/EditContextConstants.inl>
+#include <AzCore/Serialization/SerializeContext.h>
+
+namespace ROS2
+{
+    void ROS2SensorComponent::Activate()
+    {
+        AZ::TickBus::Handler::BusConnect();
+    }
+
+    void ROS2SensorComponent::Deactivate()
+    {
+        AZ::TickBus::Handler::BusDisconnect();
+    }
+
+    void ROS2SensorComponent::Reflect(AZ::ReflectContext* context)
+    {
+        SensorConfiguration::Reflect(context);
+        if (AZ::SerializeContext* serialize = azrtti_cast<AZ::SerializeContext*>(context))
+        {
+            serialize->Class<ROS2SensorComponent, AZ::Component>()
+                ->Version(1)
+                ->Field("SensorConfiguration", &ROS2SensorComponent::m_sensorConfiguration)
+                ;
+
+            if (AZ::EditContext* ec = serialize->GetEditContext())
+            {
+                ec->Class<ROS2SensorComponent>("ROS2 Sensor", "Base component for sensors")
+                    ->DataElement(AZ::Edit::UIHandlers::Default, &ROS2SensorComponent::m_sensorConfiguration, "Sensor configuration", "Sensor configuration")
+                    ;
+            }
+        }
+    }
+
+    AZStd::string ROS2SensorComponent::GetNamespace() const
+    {
+        // TODO - hold frame?
+        auto ros2Frame = GetEntity()->FindComponent<ROS2FrameComponent>();
+        return ros2Frame->GetNamespace();
+    };
+
+    AZStd::string ROS2SensorComponent::GetFrameID() const
+    {
+        auto ros2Frame = GetEntity()->FindComponent<ROS2FrameComponent>();
+        return ros2Frame->GetFrameID();
+    }
+
+    void ROS2SensorComponent::GetRequiredServices(AZ::ComponentDescriptor::DependencyArrayType& required)
+    {
+        required.push_back(AZ_CRC("ROS2Frame"));
+    }
+
+    void ROS2SensorComponent::OnTick([[maybe_unused]] float deltaTime, [[maybe_unused]] AZ::ScriptTimePoint time)
+    {
+        if (!m_sensorConfiguration.m_publishingEnabled)
+        {
+            return;
+        }
+
+        auto frequency = m_sensorConfiguration.m_frequency;
+
+        // TODO - add range validation (Attributes?)
+        auto frameTime = frequency == 0 ? 1 : 1 / frequency;
+
+        static float elapsed = 0;
+        elapsed += deltaTime;
+        if (elapsed < frameTime)
+            return;
+
+        elapsed -= frameTime;
+        if (deltaTime > frameTime)
+        {   // Frequency higher than possible, not catching up, just keep going with each frame.
+            elapsed = 0;
+        }
+
+        // Note that sensor frequency can be limited by simulation tick rate (if higher sensor Hz is desired).
+        FrequencyTick();
+    }
+} // namespace ROS2

--- a/Code/Source/Sensor/ROS2SensorComponent.h
+++ b/Code/Source/Sensor/ROS2SensorComponent.h
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+#pragma once
+
+#include <AzCore/Component/Component.h>
+#include <AzCore/Component/TickBus.h>
+#include <AzCore/std/smart_ptr/unique_ptr.h>
+#include "SensorConfiguration.h"
+
+namespace ROS2
+{
+    /// Captures common behavior of ROS2 sensor components. Derive to implement ROS2 sensors
+    class ROS2SensorComponent
+        : public AZ::Component
+        , public AZ::TickBus::Handler // TODO - high resolution tick source?
+    {
+    public:
+        ROS2SensorComponent() = default;
+        virtual ~ROS2SensorComponent() = default;
+        AZ_COMPONENT(ROS2SensorComponent, "{91BCC1E9-6D93-4466-9CDB-E73D497C6B5E}", AZ::Component);
+
+        // AZ::Component interface implementation.
+        void Activate() override;
+        void Deactivate() override;
+
+        // Required Reflect function.
+        static void Reflect(AZ::ReflectContext* context);
+        void OnTick(float deltaTime, AZ::ScriptTimePoint time) override;
+        static void GetRequiredServices(AZ::ComponentDescriptor::DependencyArrayType& required);
+
+    protected:
+        AZStd::string GetNamespace() const;
+        AZStd::string GetFrameID() const; // includes namespace
+
+        // TODO - Editor component: validation of fields, constraints between values and so on
+        SensorConfiguration m_sensorConfiguration;
+
+    private:
+        virtual void FrequencyTick() { }; // Override to implement sensor behavior
+    };
+}  // namespace ROS2

--- a/Code/Source/Sensor/SensorConfiguration.cpp
+++ b/Code/Source/Sensor/SensorConfiguration.cpp
@@ -35,7 +35,7 @@ namespace ROS2
                     ->ClassElement(AZ::Edit::ClassElements::EditorData, "")
                     ->DataElement(AZ::Edit::UIHandlers::Default, &SensorConfiguration::m_visualise, "Visualise", "Visualise")
                     ->DataElement(AZ::Edit::UIHandlers::Default, &SensorConfiguration::m_publishingEnabled, "Publishing Enabled", "Toggle publishing for topic")
-                    ->DataElement(AZ::Edit::UIHandlers::Default, &SensorConfiguration::m_frequency, "Frequency", "Frequency of publishing")
+                    ->DataElement(AZ::Edit::UIHandlers::Default, &SensorConfiguration::m_frequency, "Frequency", "Frequency of publishing [Hz]")
                     ->DataElement(AZ::Edit::UIHandlers::Default, &SensorConfiguration::m_publishersConfigurations, "Publishers", "Publishers")
                         ->Attribute(AZ::Edit::Attributes::AutoExpand, true)
                         ->Attribute(AZ::Edit::Attributes::Visibility, AZ::Edit::PropertyVisibility::ShowChildrenOnly)

--- a/Code/Source/Sensor/SensorConfiguration.cpp
+++ b/Code/Source/Sensor/SensorConfiguration.cpp
@@ -1,0 +1,48 @@
+/*
+* Copyright (c) Contributors to the Open 3D Engine Project.
+* For complete copyright and license terms please see the LICENSE at the root of this distribution.
+*
+* SPDX-License-Identifier: Apache-2.0 OR MIT
+*
+*/
+
+#pragma once
+
+#include "Sensor/SensorConfiguration.h"
+#include <AzCore/Serialization/EditContext.h>
+#include <AzCore/Serialization/EditContextConstants.inl>
+
+namespace ROS2
+{
+    void SensorConfiguration::Reflect(AZ::ReflectContext* context)
+    {
+        PublisherConfiguration::Reflect(context);
+        if (auto serializeContext = azrtti_cast<AZ::SerializeContext*>(context))
+        {
+            serializeContext->RegisterGenericType<AZStd::shared_ptr<PublisherConfiguration>>();
+            serializeContext->RegisterGenericType<AZStd::map<AZStd::string, AZStd::shared_ptr<PublisherConfiguration>>>();
+            serializeContext->Class<SensorConfiguration>()
+                ->Version(2)
+                ->Field("Visualise", &SensorConfiguration::m_visualise)
+                ->Field("Publishing Enabled", &SensorConfiguration::m_publishingEnabled)
+                ->Field("Frequency (HZ)", &SensorConfiguration::m_frequency)
+                ->Field("Publishers", &SensorConfiguration::m_publishersConfigurations)
+                ;
+
+            if (AZ::EditContext* ec = serializeContext->GetEditContext())
+            {
+                ec->Class<SensorConfiguration>("ROS2 Sensor Configuration", "Sensor configuration")
+                    ->ClassElement(AZ::Edit::ClassElements::EditorData, "")
+                    ->DataElement(AZ::Edit::UIHandlers::Default, &SensorConfiguration::m_visualise, "Visualise", "Visualise")
+                    ->DataElement(AZ::Edit::UIHandlers::Default, &SensorConfiguration::m_publishingEnabled, "Publishing Enabled", "Toggle publishing for topic")
+                    ->DataElement(AZ::Edit::UIHandlers::Default, &SensorConfiguration::m_frequency, "Frequency", "Frequency of publishing")
+                    ->DataElement(AZ::Edit::UIHandlers::Default, &SensorConfiguration::m_publishersConfigurations, "Publishers", "Publishers")
+                        ->Attribute(AZ::Edit::Attributes::AutoExpand, true)
+                        ->Attribute(AZ::Edit::Attributes::Visibility, AZ::Edit::PropertyVisibility::ShowChildrenOnly)
+                        ->Attribute(AZ::Edit::Attributes::ContainerCanBeModified, false)
+                        ->ElementAttribute(AZ::Edit::Attributes::AutoExpand, true)
+                    ;
+            }
+        }
+    }
+}  // namespace ROS2

--- a/Code/Source/Sensor/SensorConfiguration.h
+++ b/Code/Source/Sensor/SensorConfiguration.h
@@ -21,10 +21,7 @@ namespace ROS2
     struct SensorConfiguration
     {
     public:
-        AZ_CLASS_ALLOCATOR(SensorConfiguration, AZ::SystemAllocator, 0);
-        AZ_RTTI(SensorConfiguration, "{4755363D-0B5A-42D7-BBEF-152D87BA10D7}");
-        SensorConfiguration() = default;
-        virtual ~SensorConfiguration() = default;
+        AZ_TYPE_INFO(SensorConfiguration, "{4755363D-0B5A-42D7-BBEF-152D87BA10D7}");
         static void Reflect(AZ::ReflectContext* context);
 
         // Will typically be 1-3 elements (3 max for known sensors).

--- a/Code/Source/Sensor/SensorConfiguration.h
+++ b/Code/Source/Sensor/SensorConfiguration.h
@@ -1,0 +1,40 @@
+/*
+* Copyright (c) Contributors to the Open 3D Engine Project.
+* For complete copyright and license terms please see the LICENSE at the root of this distribution.
+*
+* SPDX-License-Identifier: Apache-2.0 OR MIT
+*
+*/
+
+#pragma once
+
+#include <AzCore/Memory/SystemAllocator.h>
+#include <AzCore/RTTI/RTTI.h>
+#include <AzCore/Serialization/SerializeContext.h>
+#include <AzCore/std/smart_ptr/shared_ptr.h>
+#include <AzCore/std/containers/map.h>
+#include "PublisherConfiguration.h"
+
+namespace ROS2
+{
+    /// General configuration for sensors
+    struct SensorConfiguration
+    {
+    public:
+        AZ_CLASS_ALLOCATOR(SensorConfiguration, AZ::SystemAllocator, 0);
+        AZ_RTTI(SensorConfiguration, "{4755363D-0B5A-42D7-BBEF-152D87BA10D7}");
+        SensorConfiguration() = default;
+        virtual ~SensorConfiguration() = default;
+        static void Reflect(AZ::ReflectContext* context);
+
+        // Will typically be 1-3 elements (3 max for known sensors).
+        AZStd::map<AZStd::string, AZStd::shared_ptr<PublisherConfiguration>> m_publishersConfigurations;
+
+        // TODO - consider moving frequency, publishingEnabled to publisherConfiguration if any sensor has
+        // a couple of publishers for which we want different values of these fields
+        float m_frequency = 10;
+        bool m_publishingEnabled = true;
+        bool m_visualise = true;
+    };
+}  // namespace ROS2
+

--- a/Code/ros2_files.cmake
+++ b/Code/ros2_files.cmake
@@ -6,9 +6,17 @@
 set(FILES
     Source/Clock/SimulationClock.cpp
     Source/Clock/SimulationClock.h
+    Source/QoS/QoS.cpp
+    Source/QoS/QoS.h
     Source/ROS2ModuleInterface.h
     Source/ROS2SystemComponent.cpp
     Source/ROS2SystemComponent.h
+    Source/Sensor/PublisherConfiguration.cpp
+    Source/Sensor/PublisherConfiguration.h
+    Source/Sensor/ROS2SensorComponent.cpp
+    Source/Sensor/ROS2SensorComponent.h
+    Source/Sensor/SensorConfiguration.cpp
+    Source/Sensor/SensorConfiguration.h
     Source/Frame/NamespaceConfiguration.cpp
     Source/Frame/NamespaceConfiguration.h
     Source/Frame/ROS2FrameComponent.cpp


### PR DESCRIPTION
- Base component for ROS2 sensors
- Includes: sensor configuration. Fixes #14
- Includes: publisher configuration. Multiple publishers are supported for each sensor. Fixes #15.
- Includes: Quality of Service (QoS) settings for publishers, including correct defaults. Fixes #16
- Publishing on/off - fixes #8

Note: component itself cannot be added in the Editor. To see the Editor behavior, use development branch
and add a Lidar Component (which dervies from ROS2SensorComponent).

Signed-off-by: Adam Dabrowski <adam.dabrowski@robotec.ai>