### PR TITLE
Switched sensor configuration map entries from pointers to by value

### DIFF
--- a/Code/Source/Sensor/PublisherConfiguration.h
+++ b/Code/Source/Sensor/PublisherConfiguration.h
@@ -22,16 +22,6 @@ namespace ROS2
         AZ_TYPE_INFO(PublisherConfiguration, "{7F875348-F2F9-404A-841E-D9A749EA4E79}");
         static void Reflect(AZ::ReflectContext* context);
 
-        bool operator==(const PublisherConfiguration& other) const
-        {
-            if (m_type != other.m_type)
-            {
-                return false;
-            }
-
-            return m_topic == other.m_topic;
-        }
-
         AZStd::string m_type = "std_msgs::msg::Empty";
         AZStd::string m_topic = "default_topic";
 

--- a/Code/Source/Sensor/ROS2SensorComponent.h
+++ b/Code/Source/Sensor/ROS2SensorComponent.h
@@ -22,7 +22,7 @@ namespace ROS2
     public:
         ROS2SensorComponent() = default;
         virtual ~ROS2SensorComponent() = default;
-        AZ_COMPONENT(ROS2SensorComponent, "{91BCC1E9-6D93-4466-9CDB-E73D497C6B5E}", AZ::Component);
+        AZ_COMPONENT(ROS2SensorComponent, "{91BCC1E9-6D93-4466-9CDB-E73D497C6B5E}");
 
         // AZ::Component interface implementation.
         void Activate() override;

--- a/Code/Source/Sensor/SensorConfiguration.h
+++ b/Code/Source/Sensor/SensorConfiguration.h
@@ -25,7 +25,7 @@ namespace ROS2
         static void Reflect(AZ::ReflectContext* context);
 
         // Will typically be 1-3 elements (3 max for known sensors).
-        AZStd::map<AZStd::string, AZStd::shared_ptr<PublisherConfiguration>> m_publishersConfigurations;
+        AZStd::map<AZStd::string, PublisherConfiguration> m_publishersConfigurations;
 
         // TODO - consider moving frequency, publishingEnabled to publisherConfiguration if any sensor has
         // a couple of publishers for which we want different values of these fields


### PR DESCRIPTION
Includes a minor cleanup:
- removed unnecessary == operator from PublisherConfiguration
- removed unnecessary Component parent in macro (since it is default)

Fix for #43

Signed-off-by: Adam Dabrowski <adam.dabrowski@robotec.ai>