### PR TITLE
Lidar Component

### DIFF
--- a/Code/Source/Lidar/LidarRaycaster.cpp
+++ b/Code/Source/Lidar/LidarRaycaster.cpp
@@ -19,6 +19,7 @@ namespace ROS2
     {
         AZStd::vector<AZ::Vector3> results;
         AzPhysics::SceneQueryRequests requests;
+        requests.reserve(directions.size());
         for (const AZ::Vector3& direction : directions)
         {   // NOTE - performance-wise, consider reusing requests
             AZStd::shared_ptr<AzPhysics::RayCastRequest> request = AZStd::make_shared<AzPhysics::RayCastRequest>();

--- a/Code/Source/Lidar/LidarRaycaster.cpp
+++ b/Code/Source/Lidar/LidarRaycaster.cpp
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+#include "LidarRaycaster.h"
+#include <AzFramework/Physics/PhysicsScene.h>
+#include <AzCore/Interface/Interface.h>
+#include <AzFramework/Physics/Common/PhysicsSceneQueries.h>
+#include <AzCore/std/smart_ptr/shared_ptr.h>
+#include <AzCore/std/smart_ptr/make_shared.h>
+
+namespace ROS2
+{
+    // A simplified, non-optimized first version. TODO - generalize results (fields)
+    AZStd::vector<AZ::Vector3> LidarRaycaster::PerformRaycast(const AZ::Vector3& start, const AZStd::vector<AZ::Vector3>& directions, float distance)
+    {
+        AZStd::vector<AZ::Vector3> results;
+        AzPhysics::SceneQueryRequests requests;
+        for (const AZ::Vector3& direction : directions)
+        {   // NOTE - performance-wise, consider reusing requests
+            AZStd::shared_ptr<AzPhysics::RayCastRequest> request = AZStd::make_shared<AzPhysics::RayCastRequest>();
+            request->m_start = start;
+            request->m_direction = direction;
+            request->m_distance = distance;
+            request->m_reportMultipleHits = false;
+            requests.emplace_back(AZStd::move(request));
+        }
+
+        auto* sceneInterface = AZ::Interface<AzPhysics::SceneInterface>::Get();
+        AzPhysics::SceneHandle sceneHandle = sceneInterface->GetSceneHandle(AzPhysics::DefaultPhysicsSceneName);
+        if (sceneHandle == AzPhysics::InvalidSceneHandle)
+        {
+            AZ_Warning("LidarRaycaster", false, "No valid scene handle");
+            return results;
+        }
+        auto requestResults = sceneInterface->QuerySceneBatch(sceneHandle, requests);
+        for (const auto& requestResult : requestResults)
+        {   // TODO - check flag for SceneQuery::ResultFlags::Position
+            if (requestResult.m_hits.size() > 0)
+            {
+                results.push_back(requestResult.m_hits[0].m_position);
+            }
+        }
+        return results;
+    }
+} // namespace ROS2

--- a/Code/Source/Lidar/LidarRaycaster.h
+++ b/Code/Source/Lidar/LidarRaycaster.h
@@ -1,0 +1,22 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+#pragma once
+#include <AzCore/Math/Vector3.h>
+#include <AzCore/std/containers/vector.h>
+
+// TODO - switch to interface
+namespace ROS2
+{
+    class LidarRaycaster
+    {
+    public:
+        // TODO - different starting points for rays, distance from reference point, noise models, rotating mirror sim, other
+        // TODO - customized settings. Encapsulate in lidar definition and pass in constructor, update transform.
+        AZStd::vector<AZ::Vector3> PerformRaycast(const AZ::Vector3& start, const AZStd::vector<AZ::Vector3>& directions, float distance);
+    };
+}  // namespace ROS2

--- a/Code/Source/Lidar/LidarTemplate.cpp
+++ b/Code/Source/Lidar/LidarTemplate.cpp
@@ -5,7 +5,6 @@
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *
  */
-#pragma once
 
 #include "LidarTemplate.h"
 #include <AzCore/Serialization/EditContext.h>

--- a/Code/Source/Lidar/LidarTemplate.cpp
+++ b/Code/Source/Lidar/LidarTemplate.cpp
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+#pragma once
+
+#include "LidarTemplate.h"
+#include <AzCore/Serialization/EditContext.h>
+#include <AzCore/Serialization/EditContextConstants.inl>
+
+namespace ROS2
+{
+   void LidarTemplate::Reflect(AZ::ReflectContext* context)
+   {
+       if (auto serializeContext = azrtti_cast<AZ::SerializeContext*>(context))
+       {   // TODO - some attributes are not reflected. Waiting for more realistic lidar templates
+           serializeContext->Class<LidarTemplate>()
+               ->Version(1)
+               ->Field("Layers", &LidarTemplate::m_layers)
+               ->Field("Points per layer", &LidarTemplate::m_numberOfIncrements)
+               ->Field("Max range", &LidarTemplate::m_maxRange)
+               ;
+
+           if (AZ::EditContext* ec = serializeContext->GetEditContext())
+           {
+               ec->Class<LidarTemplate>("Lidar Template", "Lidar Template")
+                   ->DataElement(AZ::Edit::UIHandlers::Default, &LidarTemplate::m_layers, "Layers", "Vertical dimension")
+                        ->Attribute(AZ::Edit::Attributes::ReadOnly, true)
+                   ->DataElement(AZ::Edit::UIHandlers::Default, &LidarTemplate::m_numberOfIncrements, "Points per layer", "Horizontal dimension")
+                        ->Attribute(AZ::Edit::Attributes::ReadOnly, true)
+                   ->DataElement(AZ::Edit::UIHandlers::Default, &LidarTemplate::m_maxRange, "Max range", "Maximum beam range [m]")
+                       ->Attribute(AZ::Edit::Attributes::ReadOnly, true)
+                       ;
+           }
+       }
+   }
+} // namespace ROS2
+

--- a/Code/Source/Lidar/LidarTemplate.h
+++ b/Code/Source/Lidar/LidarTemplate.h
@@ -26,12 +26,12 @@ namespace ROS2
 
         LidarModel m_model;
         AZStd::string m_name;
-        float m_minHAngle;
-        float m_maxHAngle;
-        float m_minVAngle;
-        float m_maxVAngle;
-        int m_layers;
-        int m_numberOfIncrements;
-        float m_maxRange;
+        float m_minHAngle = 0.0f;
+        float m_maxHAngle = 0.0f;
+        float m_minVAngle = 0.0f;
+        float m_maxVAngle = 0.0f;
+        int m_layers = 0;
+        int m_numberOfIncrements = 0;
+        float m_maxRange = 0.0f;
     };
 } // namespace ROS2

--- a/Code/Source/Lidar/LidarTemplate.h
+++ b/Code/Source/Lidar/LidarTemplate.h
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+#pragma once
+
+#include <AzCore/std/string/string.h>
+#include <AzCore/RTTI/RTTI.h>
+#include <AzCore/Serialization/SerializeContext.h>
+
+namespace ROS2
+{
+    struct LidarTemplate
+    {
+    public:
+        AZ_TYPE_INFO(LidarTemplate, "{9E9EF583-733D-4450-BBA0-ADD4D1BEFBF2}");
+        static void Reflect(AZ::ReflectContext* context);
+
+        enum LidarModel
+        {
+            Generic3DLidar
+        };
+
+        LidarModel m_model;
+        AZStd::string m_name;
+        float m_minHAngle;
+        float m_maxHAngle;
+        float m_minVAngle;
+        float m_maxVAngle;
+        int m_layers;
+        int m_numberOfIncrements;
+        float m_maxRange;
+    };
+} // namespace ROS2

--- a/Code/Source/Lidar/LidarTemplateUtils.cpp
+++ b/Code/Source/Lidar/LidarTemplateUtils.cpp
@@ -25,15 +25,15 @@ namespace ROS2
         {
             LidarTemplate generic3DLidar =
             {
-                .m_model = LidarTemplate::Generic3DLidar,
-                .m_name = "GenericLidar",
-                .m_minHAngle = -180.0f,
-                .m_maxHAngle = 180.0f,
-                .m_minVAngle = 35.0f,
-                .m_maxVAngle = -35.0f,
-                .m_layers = 24,
-                .m_numberOfIncrements = 924,
-                .m_maxRange = 100.0f
+                /*.m_model = */LidarTemplate::Generic3DLidar,
+                /*.m_name = */"GenericLidar",
+                /*.m_minHAngle = */-180.0f,
+                /*.m_maxHAngle = */180.0f,
+                /*.m_minVAngle = */35.0f,
+                /*.m_maxVAngle = */-35.0f,
+                /*.m_layers = */24,
+                /*.m_numberOfIncrements = */924,
+                /*.m_maxRange = */100.0f
             };
             templates[LidarTemplate::Generic3DLidar] = generic3DLidar;
         }

--- a/Code/Source/Lidar/LidarTemplateUtils.cpp
+++ b/Code/Source/Lidar/LidarTemplateUtils.cpp
@@ -5,7 +5,6 @@
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *
  */
-#pragma once
 
 #include "LidarTemplateUtils.h"
 #include <AzCore/std/containers/unordered_map.h>

--- a/Code/Source/Lidar/LidarTemplateUtils.cpp
+++ b/Code/Source/Lidar/LidarTemplateUtils.cpp
@@ -1,0 +1,91 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+#pragma once
+
+#include "LidarTemplateUtils.h"
+#include <AzCore/std/containers/unordered_map.h>
+#include <AzCore/Math/MathUtils.h>
+#include <AzCore/Math/Matrix4x4.h>
+#include <AzCore/Math/Vector3.h>
+#include <AzCore/Math/Quaternion.h>
+#include <AzCore/Utils/Utils.h>
+
+namespace ROS2
+{
+    LidarTemplate LidarTemplateUtils::GetTemplate(LidarTemplate::LidarModel model)
+    {
+        static std::unordered_map<LidarTemplate::LidarModel, LidarTemplate> templates;
+
+        if (templates.empty())
+        {
+            LidarTemplate generic3DLidar =
+            {
+                .m_model = LidarTemplate::Generic3DLidar,
+                .m_name = "GenericLidar",
+                .m_minHAngle = -180.0f,
+                .m_maxHAngle = 180.0f,
+                .m_minVAngle = 35.0f,
+                .m_maxVAngle = -35.0f,
+                .m_layers = 24,
+                .m_numberOfIncrements = 924,
+                .m_maxRange = 100.0f
+            };
+            templates[LidarTemplate::Generic3DLidar] = generic3DLidar;
+        }
+
+        auto it = templates.find(model);
+        if (it == templates.end())
+        {
+            return LidarTemplate(); // TODO - handle it
+        }
+
+        return it->second;
+    }
+
+    size_t LidarTemplateUtils::TotalPointCount(const LidarTemplate& t)
+    {
+        return t.m_layers * t.m_numberOfIncrements;
+    }
+
+    // TODO - lidars in reality do not have uniform distributions - populating needs to be defined per model
+    AZStd::vector<AZ::Vector3> LidarTemplateUtils::PopulateRayDirections(LidarTemplate::LidarModel model,
+                                                                         const AZ::Vector3& rootRotation)
+    {
+        auto lidarTemplate = GetTemplate(model);
+
+        const float minVertAngle = AZ::DegToRad(lidarTemplate.m_minVAngle);
+        const float maxVertAngle = AZ::DegToRad(lidarTemplate.m_maxVAngle);
+        const float minHorAngle = AZ::DegToRad(lidarTemplate.m_minHAngle);
+        const float maxHorAngle = AZ::DegToRad(lidarTemplate.m_maxHAngle);
+
+        const float verticalStep = (maxVertAngle - minVertAngle)
+            / static_cast<float>(lidarTemplate.m_layers);
+        const float horizontalStep = (maxHorAngle - minHorAngle)
+            / static_cast<float>(lidarTemplate.m_numberOfIncrements);
+
+        AZStd::vector<AZ::Vector3> directions;
+
+        for (int incr = 0; incr < lidarTemplate.m_numberOfIncrements; incr++)
+        {
+            for (int layer = 0; layer < lidarTemplate.m_layers; layer++)
+            {
+                // TODO: also include roll. Move to quaternions to avoid abnormalities
+                const float pitch = minVertAngle + layer * verticalStep + rootRotation.GetY();
+                const float yaw = minHorAngle + incr * horizontalStep + rootRotation.GetZ();
+
+                const float x = AZ::Cos(yaw) * AZ::Cos(pitch);
+                const float y = AZ::Sin(yaw) * AZ::Cos(pitch);
+                const float z = AZ::Sin(pitch);
+
+                directions.push_back(AZ::Vector3(x, y, z));
+            }
+        }
+
+        return directions;
+    }
+} // namespace ROS2

--- a/Code/Source/Lidar/LidarTemplateUtils.h
+++ b/Code/Source/Lidar/LidarTemplateUtils.h
@@ -8,6 +8,7 @@
 #pragma once
 
 #include "LidarTemplate.h"
+#include <AzCore/Math/Vector3.h>
 #include <AzCore/std/containers/vector.h>
 
 namespace ROS2

--- a/Code/Source/Lidar/LidarTemplateUtils.h
+++ b/Code/Source/Lidar/LidarTemplateUtils.h
@@ -1,0 +1,24 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+#pragma once
+
+#include "LidarTemplate.h"
+#include <AzCore/std/containers/vector.h>
+
+namespace ROS2
+{
+    class LidarTemplateUtils
+    {
+    public:
+        static LidarTemplate GetTemplate(LidarTemplate::LidarModel model);
+        static size_t TotalPointCount(const LidarTemplate& t);
+        //! Root rotation as Euler angles in radians.
+        static AZStd::vector<AZ::Vector3> PopulateRayDirections(LidarTemplate::LidarModel model,
+                                                                const AZ::Vector3& rootRotation);
+    };
+} // namespace ROS2

--- a/Code/Source/Lidar/ROS2LidarSensorComponent.cpp
+++ b/Code/Source/Lidar/ROS2LidarSensorComponent.cpp
@@ -6,9 +6,10 @@
  *
  */
 
+#include "Frame/ROS2FrameComponent.h"
 #include "Lidar/ROS2LidarSensorComponent.h"
 #include "Lidar/LidarTemplateUtils.h"
-#include "Frame/ROS2FrameComponent.h"
+#include "ROS2/ROS2Bus.h"
 #include "Utilities/ROS2Names.h"
 
 #include <Atom/RPI.Public/AuxGeom/AuxGeomFeatureProcessorInterface.h>

--- a/Code/Source/Lidar/ROS2LidarSensorComponent.cpp
+++ b/Code/Source/Lidar/ROS2LidarSensorComponent.cpp
@@ -112,7 +112,7 @@ namespace ROS2
         m_lastScanResults = m_lidarRaycaster.PerformRaycast(start, directions, distance);
         if (m_lastScanResults.empty())
         {
-            AZ_TracePrintf("Lidar Sensor Component", "No results from raycast");
+            AZ_TracePrintf("Lidar Sensor Component", "No results from raycast\n");
             return;
         }
 
@@ -142,8 +142,6 @@ namespace ROS2
             message.fields.push_back(pf);
         }
 
-        message.data.resize(message.row_step);
-
         auto lidarTM = entityTransform->GetWorldTM();
         lidarTM.Invert();
 
@@ -153,7 +151,10 @@ namespace ROS2
             point = lidarTM.TransformPoint(point);
         }
 
-        memcpy(message.data.data(), m_lastScanResults.data(), message.data.size());
+        size_t sizeInBytes = m_lastScanResults.size() * sizeof(AZ::Vector3);
+        message.data.resize(sizeInBytes);
+        AZ_Assert(message.row_step * message.height == sizeInBytes, "Inconsistency in the size of point cloud data");
+        memcpy(message.data.data(), m_lastScanResults.data(), sizeInBytes);
         m_pointCloudPublisher->publish(message);
     }
 } // namespace ROS2

--- a/Code/Source/Lidar/ROS2LidarSensorComponent.cpp
+++ b/Code/Source/Lidar/ROS2LidarSensorComponent.cpp
@@ -1,0 +1,159 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#include "Lidar/ROS2LidarSensorComponent.h"
+#include "Lidar/LidarTemplateUtils.h"
+#include "Frame/ROS2FrameComponent.h"
+#include "Utilities/ROS2Names.h"
+
+#include <Atom/RPI.Public/AuxGeom/AuxGeomFeatureProcessorInterface.h>
+#include <Atom/RPI.Public/RPISystemInterface.h>
+#include <Atom/RPI.Public/Scene.h>
+#include <AzCore/Component/Entity.h>
+#include <AzCore/Serialization/EditContext.h>
+#include <AzCore/Serialization/EditContextConstants.inl>
+
+namespace ROS2
+{
+    namespace Internal
+    {
+        const char* kPointCloudType = "sensor_msgs::msg::PointCloud2";
+    }
+
+    void ROS2LidarSensorComponent::Reflect(AZ::ReflectContext* context)
+    {
+        LidarTemplate::Reflect(context);
+        if (AZ::SerializeContext* serialize = azrtti_cast<AZ::SerializeContext*>(context))
+        {
+            serialize->Class<ROS2LidarSensorComponent, ROS2SensorComponent>()
+                ->Version(1)
+                ->Field("lidarModel", &ROS2LidarSensorComponent::m_lidarModel)
+                ;
+
+            if (AZ::EditContext* ec = serialize->GetEditContext())
+            {
+                ec->Class<ROS2LidarSensorComponent>("ROS2 Lidar Sensor", "Lidar sensor component")
+                    ->ClassElement(AZ::Edit::ClassElements::EditorData, "")
+                        ->Attribute(AZ::Edit::Attributes::AppearsInAddComponentMenu, AZ_CRC("Game"))
+                    ->DataElement(AZ::Edit::UIHandlers::ComboBox, &ROS2LidarSensorComponent::m_lidarModel, "Lidar Model", "Lidar model")
+                        ->EnumAttribute(LidarTemplate::LidarModel::Generic3DLidar, "Generic Lidar")
+                        // TODO - show lidar template field values (read only) - see Reflect for LidarTemplate
+                    ;
+            }
+        }
+    }
+
+    ROS2LidarSensorComponent::ROS2LidarSensorComponent()
+    {
+        PublisherConfiguration pc;
+        AZStd::string type = Internal::kPointCloudType;
+        pc.m_type = type;
+        pc.m_topic = "pc";
+        m_sensorConfiguration.m_frequency = 10; // TODO - dependent on lidar type
+        m_sensorConfiguration.m_publishersConfigurations.insert(AZStd::make_pair(type, pc));
+    }
+
+    void ROS2LidarSensorComponent::Visualise()
+    {
+        if (m_visualisationPoints.empty())
+        {
+            return;
+        }
+
+        if (m_drawQueue)
+        {
+            const uint8_t pixelSize = 2;
+            AZ::RPI::AuxGeomDraw::AuxGeomDynamicDrawArguments drawArgs;
+            drawArgs.m_verts = m_visualisationPoints.data();
+            drawArgs.m_vertCount = m_visualisationPoints.size();
+            drawArgs.m_colors = &AZ::Colors::Red;
+            drawArgs.m_colorCount = 1;
+            drawArgs.m_opacityType = AZ::RPI::AuxGeomDraw::OpacityType::Opaque;
+            drawArgs.m_size = pixelSize;
+            m_drawQueue->DrawPoints(drawArgs);
+        }
+    }
+
+    void ROS2LidarSensorComponent::Activate()
+    {
+        ROS2SensorComponent::Activate();
+        auto ros2Node = ROS2Interface::Get()->GetNode();
+        AZ_Assert(m_sensorConfiguration.m_publishersConfigurations.size() == 1, "Invalid configuration of publishers for lidar sensor");
+
+        const PublisherConfiguration& publisherConfig = m_sensorConfiguration.m_publishersConfigurations[Internal::kPointCloudType];
+        AZStd::string fullTopic = ROS2Names::GetNamespacedName(GetNamespace(), publisherConfig.m_topic);
+        m_pointCloudPublisher = ros2Node->create_publisher<sensor_msgs::msg::PointCloud2>(fullTopic.data(), publisherConfig.GetQoS());
+
+        if (m_sensorConfiguration.m_visualise)
+        {
+            auto defaultScene = AZ::RPI::Scene::GetSceneForEntityId(GetEntityId());
+            m_drawQueue = AZ::RPI::AuxGeomFeatureProcessorInterface::GetDrawQueueForScene(defaultScene);
+        }
+    }
+
+    void ROS2LidarSensorComponent::Deactivate()
+    {
+        ROS2SensorComponent::Deactivate();
+        m_pointCloudPublisher.reset();
+    }
+
+    void ROS2LidarSensorComponent::FrequencyTick()
+    {
+        float distance = LidarTemplateUtils::GetTemplate(m_lidarModel).m_maxRange;
+        auto entityTransform = GetEntity()->FindComponent<AzFramework::TransformComponent>(); // TODO - go through ROS2Frame
+        const auto directions = LidarTemplateUtils::PopulateRayDirections(m_lidarModel, entityTransform->GetWorldTM().GetEulerRadians());
+        AZ::Vector3 start = entityTransform->GetWorldTM().GetTranslation();
+        start.SetZ(start.GetZ() + 1.0f);
+        m_lastScanResults = m_lidarRaycaster.PerformRaycast(start, directions, distance);
+        if (m_lastScanResults.empty())
+        {
+            AZ_TracePrintf("Lidar Sensor Component", "No results from raycast");
+            return;
+        }
+
+        if (m_sensorConfiguration.m_visualise)
+        {   // Store points for visualisation purposes, before transformations occur
+            m_visualisationPoints = m_lastScanResults;
+        }
+
+        auto ros2Frame = GetEntity()->FindComponent<ROS2FrameComponent>();
+        auto message = sensor_msgs::msg::PointCloud2();
+        message.header.frame_id = ros2Frame->GetFrameID().data();
+        message.header.stamp = ROS2Interface::Get()->GetROSTimestamp();
+        message.height = 1;
+        message.width = m_lastScanResults.size();
+        message.point_step = sizeof(AZ::Vector3); // TODO - Point Fields can be custom
+        message.row_step = message.width * message.point_step;
+
+        // TODO - a list of supported fields should be returned by lidar implementation
+        std::vector<std::string> point_field_names = { "x", "y", "z"};
+        for (int i = 0; i < point_field_names.size(); i++)
+        {   // TODO - placeholder impl
+            sensor_msgs::msg::PointField pf;
+            pf.name = point_field_names[i];
+            pf.offset = i * 4;
+            pf.datatype = sensor_msgs::msg::PointField::FLOAT32;
+            pf.count = 1;
+            message.fields.push_back(pf);
+        }
+
+        message.data.resize(message.row_step);
+
+        auto lidarTM = entityTransform->GetWorldTM();
+        lidarTM.Invert();
+
+        // TODO - improve performance
+        for (auto& point : m_lastScanResults)
+        {
+            point = lidarTM.TransformPoint(point);
+        }
+
+        memcpy(message.data.data(), m_lastScanResults.data(), message.data.size());
+        m_pointCloudPublisher->publish(message);
+    }
+} // namespace ROS2

--- a/Code/Source/Lidar/ROS2LidarSensorComponent.h
+++ b/Code/Source/Lidar/ROS2LidarSensorComponent.h
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+#pragma once
+
+#include <rclcpp/publisher.hpp>
+#include <sensor_msgs/msg/point_cloud2.hpp>
+#include <Atom/RPI.Public/AuxGeom/AuxGeomDraw.h>
+#include <AzCore/Serialization/SerializeContext.h>
+#include "Sensor/ROS2SensorComponent.h"
+#include "Lidar/LidarTemplate.h"
+#include "Lidar/LidarRaycaster.h"
+
+namespace ROS2
+{
+    class ROS2LidarSensorComponent
+        : public ROS2SensorComponent
+    {
+    public:
+        AZ_COMPONENT(ROS2LidarSensorComponent, "{502A955F-7742-4E23-AD77-5E4063739DCA}", ROS2SensorComponent);
+        ROS2LidarSensorComponent();
+        ~ROS2LidarSensorComponent() = default;
+        static void Reflect(AZ::ReflectContext* context);
+        void Activate() override;
+        void Deactivate() override;
+
+    private:
+        void FrequencyTick() override;
+        void Visualise() override;
+
+        LidarTemplate::LidarModel m_lidarModel = LidarTemplate::Generic3DLidar;
+        LidarRaycaster m_lidarRaycaster;
+        std::shared_ptr<rclcpp::Publisher<sensor_msgs::msg::PointCloud2>> m_pointCloudPublisher;
+        // TODO - also add a data acquisition implementation choice (and consider propagating abstraction upwards)
+
+        // Used only when visualisation is on - points differ since they are in global transform as opposed to local
+        AZStd::vector<AZ::Vector3> m_visualisationPoints;
+        AZ::RPI::AuxGeomDrawPtr m_drawQueue;
+
+        AZStd::vector<AZ::Vector3> m_lastScanResults;
+    };
+}  // namespace ROS2

--- a/Code/Source/QoS/QoS.cpp
+++ b/Code/Source/QoS/QoS.cpp
@@ -6,8 +6,6 @@
 *
 */
 
-#pragma once
-
 #include "QoS.h"
 #include <AzCore/Serialization/EditContext.h>
 #include <AzCore/Serialization/SerializeContext.h>

--- a/Code/Source/ROS2ModuleInterface.h
+++ b/Code/Source/ROS2ModuleInterface.h
@@ -31,7 +31,8 @@ namespace ROS2
             m_descriptors.insert(m_descriptors.end(), {
                 ROS2SystemComponent::CreateDescriptor(),
                 ROS2SensorComponent::CreateDescriptor(),
-                ROS2ImuSensorComponent::CreateDescriptor(),
+                ROS2ImuSensorComponent::CreateDescriptor(), 
+                ROS2LidarSensorComponent::CreateDescriptor(),
                 ROS2FrameComponent::CreateDescriptor(),
                 ROS2RobotControlComponent::CreateDescriptor()
                 });

--- a/Code/ros2_files.cmake
+++ b/Code/ros2_files.cmake
@@ -8,6 +8,14 @@ set(FILES
     Source/Clock/SimulationClock.h
     Source/Imu/ROS2ImuSensorComponent.cpp
     Source/Imu/ROS2ImuSensorComponent.h
+    Source/Lidar/LidarRaycaster.cpp
+    Source/Lidar/LidarRaycaster.h
+    Source/Lidar/LidarTemplate.cpp
+    Source/Lidar/LidarTemplate.h
+    Source/Lidar/LidarTemplateUtils.cpp
+    Source/Lidar/LidarTemplateUtils.h
+    Source/Lidar/ROS2LidarSensorComponent.cpp
+    Source/Lidar/ROS2LidarSensorComponent.h
     Source/QoS/QoS.cpp
     Source/QoS/QoS.h
     Source/RobotControl/RobotControl.h


### PR DESCRIPTION
- Lidar templates to pick from. Comes with just one for now: Generic Lidar.
- Raycaster based on PhysX scene queries
- Visualising data with AuxGeom
- Transformation from global to local frame
- Filling and publishing ros2 PointCloud2 message

Signed-off-by: Adam Dabrowski <adam.dabrowski@robotec.ai>

Note: this is a first iteration of the lidar component.