### PR TITLE
Add URDF to FBX conversion

### DIFF
--- a/Code/Source/URDF/UrdfToFbxConverter.cpp
+++ b/Code/Source/URDF/UrdfToFbxConverter.cpp
@@ -9,22 +9,96 @@
 #include "UrdfToFbxConverter.h"
 
 #include <AzCore/std/string/string.h>
-
-#include "UrdfParser.h"
-#include "FbxGenerator.h"
+#include <AzCore/Console/Console.h>
 
 namespace ROS2
 {
-    AZStd::string UrdfToFbxConverter::ConvertUrdfToFbx(const AZStd::string & urdfString)
+    AZStd::string UrdfToFbxConverter::Convert(const AZStd::string & urdfString)
     {
-        // TODO: Add implementation
+        // 1. Parse URDF
+        const auto urdf = UrdfParser::Parse(urdfString.data());
 
-        // Workflow
-        // 1. Parse URDF with UrdfParser
-        // 2. Create FBX file with FbxGenerator
-        // 3. Add each object from URDF based structure to FBX generator.
+        // 2. Add materials to FBX
+        AddMaterialsToFbxGenerator(urdf);
 
-        return "";
+        // 3. Add links from URDF based structure to FBX generator in Depth First order
+        const auto root = urdf->getRoot();
+
+        std::stack<urdf::Link> stack;
+        stack.push(*root);
+
+        while(!stack.empty())
+        {
+            const auto link = stack.top();
+            stack.pop();
+
+            AddLinkToFbxGenerator(link);
+
+            // Add childs to stack
+            for (const auto & child : link.child_links)
+            {
+                stack.push(*child);
+            }
+        }
+
+        return m_generator.GetFbxString().data();
+    }
+
+    AZStd::string UrdfToFbxConverter::ConvertAndSaveToFile(
+        const AZStd::string & urdfString, const AZStd::string & filePath)
+    {
+        const auto fbxContent = Convert(urdfString);
+        m_generator.SaveToFile(filePath.data());
+
+        return fbxContent;
+    }
+
+    void UrdfToFbxConverter::AddLinkToFbxGenerator(const urdf::Link & link)
+    {
+        const auto linkGeometry = link.visual->geometry;
+
+        if (linkGeometry->type == urdf::Geometry::BOX)
+        {
+            auto boxGeometry = std::dynamic_pointer_cast<urdf::Box>(linkGeometry);
+            const double cubeSize = boxGeometry->dim.x; // TODO: Handle box in FBX instead of cube
+            AZStd::string materialName(link.visual->material_name.c_str());
+            auto objectId = m_generator.AddCubeObject(link.name.c_str(), cubeSize, m_materialNamesToIds[materialName]);
+            m_objectNameToObjectId[link.name.c_str()] = objectId;
+        }
+        else
+        {
+            AZ_Warning(__func__, false, "Only box geometry is supported.");
+        }
+
+        // Set proper relations between links (only root has no parent)
+        // TODO: handle joints tranformations
+        if (const auto & parent = link.getParent())
+        {
+            const auto parentId = m_objectNameToObjectId[parent->name.c_str()];
+            const auto childId = m_objectNameToObjectId[link.name.c_str()];
+            m_generator.SetRelationBetweenObjects(parentId, childId);
+        }
+    }
+
+    void UrdfToFbxConverter::AddMaterialsToFbxGenerator(const urdf::ModelInterfaceSharedPtr & urdfModel)
+    {
+        if (!urdfModel)
+        {
+            AZ_Error(__func__, false, "Missing URDF model.");
+            return;
+        }
+
+        for (const auto & e : urdfModel->materials_)
+        {
+            const auto material = e.second;
+            const AZStd::string materialName(material->name.c_str());
+            const auto materialColor = material->color;
+            const Fbx::Color fbxColor(materialColor.r, materialColor.g, materialColor.b);
+            const auto materialId = m_generator.AddMaterial(materialName, fbxColor);
+            m_materialNamesToIds[materialName] = materialId;
+
+            AZ_Printf(__func__, "Add new material: %s", materialName.c_str());
+        }
     }
 
 } // namespace ROS2

--- a/Code/Source/URDF/UrdfToFbxConverter.h
+++ b/Code/Source/URDF/UrdfToFbxConverter.h
@@ -10,13 +10,32 @@
 
 #include <AzCore/std/string/string.h>
 
+#include <AzCore/std/string/string.h>
+#include <AzCore/std/containers/map.h>
+#include <AzCore/Memory/SystemAllocator.h>
+
+#include "FbxGenerator.h"
+#include "UrdfParser.h"
+
 namespace ROS2
 {
     //! Class for conversion from URDF to Filmbox (.fbx) files
     class UrdfToFbxConverter
     {
     public:
-        AZStd::string ConvertUrdfToFbx(const AZStd::string & urdfString);
+        AZ_CLASS_ALLOCATOR(UrdfToFbxConverter, AZ::SystemAllocator, 0);
+
+        AZStd::string Convert(const AZStd::string & urdfString);
+
+        AZStd::string ConvertAndSaveToFile(const AZStd::string & urdfString, const AZStd::string & filePath);
+
+    private:
+        void AddLinkToFbxGenerator(const urdf::Link & urdfLink);
+        void AddMaterialsToFbxGenerator(const urdf::ModelInterfaceSharedPtr & urdfModel);
+
+        Fbx::FbxGenerator m_generator;
+        AZStd::map<AZStd::string, Id> m_materialNamesToIds;
+        AZStd::map<AZStd::string, Id> m_objectNameToObjectId;
     };
 
 } // namespace ROS2

--- a/Code/Tests/UrdfToFbxConverterTest.cpp
+++ b/Code/Tests/UrdfToFbxConverterTest.cpp
@@ -8,6 +8,8 @@
 
 #include <URDF/UrdfToFbxConverter.h>
 
+#include <AzCore/std/string/string.h>
+#include <AzCore/UnitTest/TestTypes.h>
 #include <AzTest/AzTest.h>
 #include <AzCore/UnitTest/TestTypes.h>
 
@@ -16,39 +18,244 @@ namespace UnitTest
 
 class UrdfToFbxConverterTest : public AllocatorsTestFixture
 {
-    public:
-        AZStd::string GetUrdfWithOneLink()
-        {
-            return
-                "<robot name=\"test_one_link\">"
-                "  <link name=\"link1\">"
-                "    <inertial>"
-                "      <mass value=\"1.0\"/>"
-                "      <inertia ixx=\"1.0\" iyy=\"1.0\" izz=\"1.0\" ixy=\"0\" ixz=\"0\" iyz=\"0\"/>"
-                "    </inertial>"
-                "    <visual>"
-                "      <geometry>"
-                "        <box size=\"1.0 2.0 1.0\"/>"
-                "      </geometry>"
-                "      <material name=\"black\"/>"
-                "    </visual>"
-                "    <collision>"
-                "      <geometry>"
-                "        <box size=\"1.0 2.0 1.0\"/>"
-                "      </geometry>"
-                "    </collision>"
-                "  </link>"
-                "</robot>";
-        }
+public:
+    AZStd::string GetUrdfWithOneLink()
+    {
+        return
+            "<robot name=\"test_one_link\">"
+            "  <material name=\"black\">"
+            "    <color rgba=\"0.0 0.0 0.0 1.0\"/>"
+            "  </material>"
+            "  <link name=\"link1\">"
+            "    <inertial>"
+            "      <mass value=\"1.0\"/>"
+            "      <inertia ixx=\"1.0\" iyy=\"1.0\" izz=\"1.0\" ixy=\"0\" ixz=\"0\" iyz=\"0\"/>"
+            "    </inertial>"
+            "    <visual>"
+            "      <geometry>"
+            "        <box size=\"1.0 2.0 1.0\"/>"
+            "      </geometry>"
+            "      <material name=\"black\"/>"
+            "    </visual>"
+            "    <collision>"
+            "      <geometry>"
+            "        <box size=\"1.0 2.0 1.0\"/>"
+            "      </geometry>"
+            "    </collision>"
+            "  </link>"
+            "</robot>";
+    }
+
+    AZStd::string GetUrdfWithTwoLinksAndOneJoint()
+    {
+        return
+            "<robot name=\"test_one_link\">"
+            "  <material name=\"black\">"
+            "    <color rgba=\"0.0 0.0 0.0 1.0\"/>"
+            "  </material>"
+            "  <material name=\"blue\">"
+            "    <color rgba=\"0.0 0.0 0.8 1.0\"/>"
+            "  </material>"
+            "  <link name=\"link1\">"
+            "    <inertial>"
+            "      <mass value=\"1.0\"/>"
+            "      <inertia ixx=\"1.0\" iyy=\"1.0\" izz=\"1.0\" ixy=\"0\" ixz=\"0\" iyz=\"0\"/>"
+            "    </inertial>"
+            "    <visual>"
+            "      <geometry>"
+            "        <box size=\"1.0 2.0 1.0\"/>"
+            "      </geometry>"
+            "      <material name=\"black\"/>"
+            "    </visual>"
+            "    <collision>"
+            "      <geometry>"
+            "        <box size=\"1.0 2.0 1.0\"/>"
+            "      </geometry>"
+            "    </collision>"
+            "  </link>"
+            "  <link name=\"link2\">"
+            "    <inertial>"
+            "      <mass value=\"1.0\"/>"
+            "      <inertia ixx=\"1.0\" iyy=\"1.0\" izz=\"1.0\" ixy=\"0\" ixz=\"0\" iyz=\"0\"/>"
+            "    </inertial>"
+            "    <visual>"
+            "      <geometry>"
+            "        <box size=\"1.0 2.0 1.0\"/>"
+            "      </geometry>"
+            "      <material name=\"blue\"/>"
+            "    </visual>"
+            "    <collision>"
+            "      <geometry>"
+            "        <box size=\"2.0 2.0 1.0\"/>"
+            "      </geometry>"
+            "    </collision>"
+            "  </link>"
+            "  <joint name=\"joint1\" type=\"continuous\">"
+            "    <parent link=\"link1\"/>"
+            "    <child link=\"link2\"/>"
+            "    <origin xyz=\"0.5 0.25 0.0\" rpy=\"0 0 0\"/>"
+            "    <axis xyz=\"0 0 1\"/>"
+            "  </joint>"
+            "</robot>";
+    }
+
+    AZStd::string GetSimpleRobotUrdf()
+    {
+        return
+            "<robot name=\"simple_robot\">"
+            "  <material name=\"black\">"
+            "    <color rgba=\"0.0 0.0 0.0 1.0\"/>"
+            "  </material>"
+            "  <material name=\"blue\">"
+            "    <color rgba=\"0.0 0.0 0.8 1.0\"/>"
+            "  </material>"
+            "  <link name=\"base_link\">"
+            "    <visual>"
+            "      <geometry>"
+            "        <box size=\"1.0 2.0 1.0\"/>"
+            "      </geometry>"
+            "      <material name=\"blue\"/>"
+            "    </visual>"
+            "  </link>"
+            "  <link name=\"wheel_bl\">"
+            "    <visual>"
+            "      <geometry>"
+            "        <box size=\"1.0 2.0 1.0\"/>"
+            "      </geometry>"
+            "      <material name=\"black\"/>"
+            "    </visual>"
+            "  </link>"
+            "  <link name=\"wheel_br\">"
+            "    <visual>"
+            "      <geometry>"
+            "        <box size=\"1.0 2.0 1.0\"/>"
+            "      </geometry>"
+            "      <material name=\"black\"/>"
+            "    </visual>"
+            "  </link>"
+            "  <link name=\"wheel_fl\">"
+            "    <visual>"
+            "      <geometry>"
+            "        <box size=\"1.0 2.0 1.0\"/>"
+            "      </geometry>"
+            "      <material name=\"black\"/>"
+            "    </visual>"
+            "  </link>"
+            "  <link name=\"wheel_fr\">"
+            "    <visual>"
+            "      <geometry>"
+            "        <box size=\"1.0 2.0 1.0\"/>"
+            "      </geometry>"
+            "      <material name=\"black\"/>"
+            "    </visual>"
+            "  </link>"
+            "  <link name=\"head\">"
+            "    <visual>"
+            "      <geometry>"
+            "        <box size=\"1.0 2.0 1.0\"/>"
+            "      </geometry>"
+            "      <material name=\"black\"/>"
+            "    </visual>"
+            "  </link>"
+            "  <link name=\"camera_link\">"
+            "    <visual>"
+            "      <geometry>"
+            "        <box size=\"1.0 2.0 1.0\"/>"
+            "      </geometry>"
+            "      <material name=\"black\"/>"
+            "    </visual>"
+            "  </link>"
+            // Joints
+            "  <joint name=\"base_link_to_wheel_bl\" type=\"continuous\">"
+            "    <parent link=\"base_link\"/>"
+            "    <child link=\"wheel_bl\"/>"
+            "    <origin xyz=\"-0.5 -0.25 0.0\" rpy=\"0 0 0\"/>"
+            "    <axis xyz=\"0 0 1\"/>"
+            "  </joint>"
+            "  <joint name=\"base_link_to_wheel_br\" type=\"continuous\">"
+            "    <parent link=\"base_link\"/>"
+            "    <child link=\"wheel_br\"/>"
+            "    <origin xyz=\"-0.5 0.25 0.0\" rpy=\"0 0 0\"/>"
+            "    <axis xyz=\"0 0 1\"/>"
+            "  </joint>"
+            "  <joint name=\"base_link_to_wheel_fl\" type=\"continuous\">"
+            "    <parent link=\"base_link\"/>"
+            "    <child link=\"wheel_fl\"/>"
+            "    <origin xyz=\"0.5 -0.25 0.0\" rpy=\"0 0 0\"/>"
+            "    <axis xyz=\"0 0 1\"/>"
+            "  </joint>"
+            "  <joint name=\"base_link_to_wheel_fr\" type=\"continuous\">"
+            "    <parent link=\"base_link\"/>"
+            "    <child link=\"wheel_fr\"/>"
+            "    <origin xyz=\"0.5 0.25 0.0\" rpy=\"0 0 0\"/>"
+            "    <axis xyz=\"0 0 1\"/>"
+            "  </joint>"
+            "  <joint name=\"base_link_to_head\" type=\"continuous\">"
+            "    <parent link=\"base_link\"/>"
+            "    <child link=\"head\"/>"
+            "    <origin xyz=\"0.0 0.0 0.5\" rpy=\"0 0 0\"/>"
+            "    <axis xyz=\"0 0 1\"/>"
+            "  </joint>"
+            "  <joint name=\"head_to_camera_link\" type=\"continuous\">"
+            "    <parent link=\"head\"/>"
+            "    <child link=\"camera_link\"/>"
+            "    <origin xyz=\"0.5 0.25 0.0\" rpy=\"0 0 0\"/>"
+            "    <axis xyz=\"0 0 1\"/>"
+            "  </joint>"
+            "</robot>";
+    }
+
+    void PrintFbxContent(const AZStd::string & str)
+    {
+        std::cout << __func__ << " fbx data:"
+            << "\n---------------\n"
+            << str.data()
+            << "\n---------------\n";
+    }
 };
 
 TEST_F(UrdfToFbxConverterTest, ConvertUrdfWithOneLink)
 {
-    ROS2::UrdfToFbxConverter converter;
-    const auto xmlStr = GetUrdfWithOneLink();
-    const auto fbxStr = converter.ConvertUrdfToFbx(xmlStr);
+    const auto urdfStr = GetUrdfWithOneLink();
 
-    // Add validation (implementation of converter is also not ready)
+    // Save generated FBX to file (it's then loaded by Asset Processor).
+    // TODO: remove temporary hardcoded path
+    AZStd::string projectPath = "/home/user/o3de/Ros2WarehouseDemo/one_link.fbx";
+
+    ROS2::UrdfToFbxConverter converter;
+    const auto fbxStr = converter.ConvertAndSaveToFile(urdfStr, projectPath);
+
+    PrintFbxContent(fbxStr);
+
+    // TODO: validation
 }
 
-} // namespace
+TEST_F(UrdfToFbxConverterTest, ConvertUrdfWithTwoLinksAndJoint)
+{
+    const auto urdfStr = GetUrdfWithTwoLinksAndOneJoint();
+
+    // Save generated FBX to file (it's then loaded by Asset Processor).
+    // TODO: remove temporary hardcoded path
+    AZStd::string projectPath = "/home/user/o3de/Ros2WarehouseDemo/two_links_one_joint.fbx";
+
+    ROS2::UrdfToFbxConverter converter;
+    const auto fbxStr = converter.ConvertAndSaveToFile(urdfStr, projectPath);
+
+    PrintFbxContent(fbxStr);
+
+    // TODO: validation
+}
+
+TEST_F(UrdfToFbxConverterTest, ConvertSimpleRobotUrdf)
+{
+    const auto urdfStr = GetSimpleRobotUrdf();
+
+    ROS2::UrdfToFbxConverter converter;
+    const auto fbxStr = converter.Convert(urdfStr);
+
+    PrintFbxContent(fbxStr);
+
+    // TODO: validation
+}
+
+} // namespace UnitTest


### PR DESCRIPTION
Changes:
- handle materials
- created tests: with two links and joint and with simple robot
- depth first search in URDF links tree and add relations based on
joints
- switched to AZStd containers
- fixed memory allocation in tests

Signed-off-by: Michal Drwiega <michal.drwiega@robotec.ai>