### PR TITLE
Lidar improvements (main)

### DIFF
--- a/Assets/Prefabs/Sensors/LidarOS2.prefab
+++ b/Assets/Prefabs/Sensors/LidarOS2.prefab
@@ -54,9 +54,90 @@
         }
     },
     "Entities": {
+        "Entity_[1273969985848]": {
+            "Id": "Entity_[1273969985848]",
+            "Name": "Sensor",
+            "Components": {
+                "Component_[10527242310063513328]": {
+                    "$type": "SelectionComponent",
+                    "Id": 10527242310063513328
+                },
+                "Component_[1058300359310703890]": {
+                    "$type": "GenericComponentWrapper",
+                    "Id": 1058300359310703890,
+                    "m_template": {
+                        "$type": "ROS2FrameComponent",
+                        "Namespace Configuration": {
+                            "Namespace Strategy": 1
+                        },
+                        "Frame Name": "lidar"
+                    }
+                },
+                "Component_[1067011392942644324]": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 1067011392942644324
+                },
+                "Component_[10842630456390194262]": {
+                    "$type": "GenericComponentWrapper",
+                    "Id": 10842630456390194262,
+                    "m_template": {
+                        "$type": "ROS2LidarSensorComponent",
+                        "SensorConfiguration": {
+                            "Publishers": {
+                                "sensor_msgs::msg::PointCloud2": {
+                                    "Type": "sensor_msgs::msg::PointCloud2",
+                                    "Topic": "pc"
+                                }
+                            }
+                        },
+                        "selfCollisionEntityId": "Entity_[417184227077]"
+                    }
+                },
+                "Component_[13013301136498148727]": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 13013301136498148727
+                },
+                "Component_[13444160964623421011]": {
+                    "$type": "EditorLockComponent",
+                    "Id": 13444160964623421011
+                },
+                "Component_[14110476541514862518]": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 14110476541514862518
+                },
+                "Component_[17124975368240161289]": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 17124975368240161289
+                },
+                "Component_[1863593986687460136]": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 1863593986687460136
+                },
+                "Component_[3070834537283917104]": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 3070834537283917104
+                },
+                "Component_[7054215981025466544]": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 7054215981025466544
+                },
+                "Component_[8854312938977545065]": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 8854312938977545065,
+                    "Parent Entity": "Entity_[417184227077]",
+                    "Transform Data": {
+                        "Translate": [
+                            0.0,
+                            0.0,
+                            0.06961321830749512
+                        ]
+                    }
+                }
+            }
+        },
         "Entity_[417184227077]": {
             "Id": "Entity_[417184227077]",
-            "Name": "shape",
+            "Name": "LidarOS2",
             "Components": {
                 "Component_[10387713135725007135]": {
                     "$type": "AZ::Render::EditorMeshComponent",
@@ -85,6 +166,9 @@
                     "$type": "EditorColliderComponent",
                     "Id": 14535670656735835043,
                     "ColliderConfiguration": {
+                        "CollisionGroupId": {
+                            "GroupId": "{DED3A46E-3588-4BB8-BADF-E3114DBA95A6}"
+                        },
                         "MaterialSelection": {
                             "MaterialIds": [
                                 {}
@@ -161,7 +245,10 @@
                 },
                 "Component_[8808389010192194694]": {
                     "$type": "EditorEntitySortComponent",
-                    "Id": 8808389010192194694
+                    "Id": 8808389010192194694,
+                    "Child Entity Order": [
+                        "Entity_[1273969985848]"
+                    ]
                 }
             }
         }

--- a/Code/Source/Lidar/LidarRaycaster.cpp
+++ b/Code/Source/Lidar/LidarRaycaster.cpp
@@ -27,6 +27,16 @@ namespace ROS2
             request->m_direction = direction;
             request->m_distance = distance;
             request->m_reportMultipleHits = false;
+            request->m_filterCallback = [selfCollider = m_selfColliderEntityId](const AzPhysics::SimulatedBody* simBody, const Physics::Shape *) {
+                if (simBody->GetEntityId() == selfCollider)
+                {
+                    return AzPhysics::SceneQuery::QueryHitType::None;
+                } 
+                else 
+                {
+                    return AzPhysics::SceneQuery::QueryHitType::Block;
+                }
+            };
             requests.emplace_back(AZStd::move(request));
         }
 
@@ -46,5 +56,9 @@ namespace ROS2
             }
         }
         return results;
+    }
+
+    void LidarRaycaster::setSelfColliderEntity(const AZ::EntityId &selfColliderEntity) {
+        m_selfColliderEntityId = selfColliderEntity;
     }
 } // namespace ROS2

--- a/Code/Source/Lidar/LidarRaycaster.h
+++ b/Code/Source/Lidar/LidarRaycaster.h
@@ -10,6 +10,7 @@
 #include <AzCore/Component/EntityId.h>
 #include <AzCore/Math/Vector3.h>
 #include <AzCore/std/containers/vector.h>
+#include <AzFramework/Physics/PhysicsScene.h>
 
 // TODO - switch to interface
 namespace ROS2
@@ -18,6 +19,15 @@ namespace ROS2
     class LidarRaycaster
     {
     public:
+
+        //! Set the Scene for the ray-casting.
+        //! This should be the scene with the Entity that holds the sensor.
+        //! @code
+        //! auto sceneHandle = AZ::RPI::Scene::GetSceneForEntityId(GetEntityId());
+        //! @endcode
+        //! @param scene that will be subject to ray-casting.
+        void SetRaycasterScene(const AzPhysics::SceneHandle& handle);
+
         //! Perform raycast against the current scene.
         //! @param start Starting point of rays. This is a simplification since there can be multiple starting points
         //! in real sensors.
@@ -29,9 +39,17 @@ namespace ROS2
         // TODO - customized settings. Encapsulate in lidar definition and pass in constructor, update transform.
         AZStd::vector<AZ::Vector3> PerformRaycast(const AZ::Vector3& start, const AZStd::vector<AZ::Vector3>& directions, float distance);
 
-        void setSelfColliderEntity(const AZ::EntityId &selfColliderEntity);
+        //! Set the lidar entity to use to filter out this lidar's collider(s) from ray-casting scene.
+        //! For example, if a lidar prefab contains a physical model with a collider, we would like ray-casts to
+        //! ignore it completely. This is a simplification due to lack of handling of transparency (e.g. lidar front glass).
+        //! @param lidarTransparentEntity entity to ignore in ray-casts. Note that all colliders within the entity will be ignored.
+        //! @note in robotics, self-detection (or ego-detection) is means detecting any part of the robot.
+        //! As such, it should be simulated to match the real data (which will also initially include self-detection).
+        void setLidarTransparentEntity(const AZ::EntityId& lidarTransparentEntityId);
 
     private:
-        AZ::EntityId m_selfColliderEntityId;
+        AzPhysics::SceneHandle m_sceneHandle;
+        AZ::EntityId m_lidarTransparentEntityId;
     };
 }  // namespace ROS2
+

--- a/Code/Source/Lidar/LidarRaycaster.h
+++ b/Code/Source/Lidar/LidarRaycaster.h
@@ -7,6 +7,7 @@
  */
 #pragma once
 
+#include <AzCore/Component/EntityId.h>
 #include <AzCore/Math/Vector3.h>
 #include <AzCore/std/containers/vector.h>
 
@@ -27,5 +28,10 @@ namespace ROS2
         // TODO - different starting points for rays, distance from reference point, noise models, rotating mirror sim, other
         // TODO - customized settings. Encapsulate in lidar definition and pass in constructor, update transform.
         AZStd::vector<AZ::Vector3> PerformRaycast(const AZ::Vector3& start, const AZStd::vector<AZ::Vector3>& directions, float distance);
+
+        void setSelfColliderEntity(const AZ::EntityId &selfColliderEntity);
+
+    private:
+        AZ::EntityId m_selfColliderEntityId;
     };
 }  // namespace ROS2

--- a/Code/Source/Lidar/LidarTemplate.cpp
+++ b/Code/Source/Lidar/LidarTemplate.cpp
@@ -15,23 +15,40 @@ namespace ROS2
    void LidarTemplate::Reflect(AZ::ReflectContext* context)
    {
        if (auto serializeContext = azrtti_cast<AZ::SerializeContext*>(context))
-       {   // TODO - some attributes are not reflected. Waiting for more realistic lidar templates
+       {
            serializeContext->Class<LidarTemplate>()
                ->Version(1)
+               ->Field("Name", &LidarTemplate::m_name)
                ->Field("Layers", &LidarTemplate::m_layers)
                ->Field("Points per layer", &LidarTemplate::m_numberOfIncrements)
+               ->Field("Min horizontal angle", &LidarTemplate::m_minHAngle)
+               ->Field("Max horizontal angle", &LidarTemplate::m_maxHAngle)
+               ->Field("Min vertical angle", &LidarTemplate::m_minVAngle)
+               ->Field("Max vertical angle", &LidarTemplate::m_maxVAngle)
                ->Field("Max range", &LidarTemplate::m_maxRange)
                ;
 
            if (AZ::EditContext* ec = serializeContext->GetEditContext())
            {
                ec->Class<LidarTemplate>("Lidar Template", "Lidar Template")
+                   ->DataElement(AZ::Edit::UIHandlers::Default, &LidarTemplate::m_name, "Name", "Custom lidar name")
                    ->DataElement(AZ::Edit::UIHandlers::Default, &LidarTemplate::m_layers, "Layers", "Vertical dimension")
-                        ->Attribute(AZ::Edit::Attributes::ReadOnly, true)
                    ->DataElement(AZ::Edit::UIHandlers::Default, &LidarTemplate::m_numberOfIncrements, "Points per layer", "Horizontal dimension")
-                        ->Attribute(AZ::Edit::Attributes::ReadOnly, true)
+                   ->DataElement(AZ::Edit::UIHandlers::Default, &LidarTemplate::m_minHAngle, "Min horizontal angle [Deg]", "Left-most reach of fov")
+                       ->Attribute(AZ::Edit::Attributes::Min, -180.0f)
+                       ->Attribute(AZ::Edit::Attributes::Max, 180.0f)
+                   ->DataElement(AZ::Edit::UIHandlers::Default, &LidarTemplate::m_maxHAngle, "Max horizontal angle [Deg]", "Right-most reach of fov")
+                       ->Attribute(AZ::Edit::Attributes::Min, -180.0f)
+                       ->Attribute(AZ::Edit::Attributes::Max, 180.0f)
+                   ->DataElement(AZ::Edit::UIHandlers::Default, &LidarTemplate::m_minVAngle, "Min vertical angle [Deg]", "Downwards reach of fov")
+                       ->Attribute(AZ::Edit::Attributes::Min, -180.0f)
+                       ->Attribute(AZ::Edit::Attributes::Max, 180.0f)
+                   ->DataElement(AZ::Edit::UIHandlers::Default, &LidarTemplate::m_maxVAngle, "Max vertical angle [Deg]", "Upwards reach of fov")
+                       ->Attribute(AZ::Edit::Attributes::Min, -180.0f)
+                       ->Attribute(AZ::Edit::Attributes::Max, 180.0f)
                    ->DataElement(AZ::Edit::UIHandlers::Default, &LidarTemplate::m_maxRange, "Max range", "Maximum beam range [m]")
-                       ->Attribute(AZ::Edit::Attributes::ReadOnly, true)
+                       ->Attribute(AZ::Edit::Attributes::Min, 0.0f)
+                       ->Attribute(AZ::Edit::Attributes::Max, 1000.0f)
                        ;
            }
        }

--- a/Code/Source/Lidar/LidarTemplate.h
+++ b/Code/Source/Lidar/LidarTemplate.h
@@ -35,8 +35,8 @@ namespace ROS2
         float m_maxHAngle = 0.0f;
         float m_minVAngle = 0.0f;
         float m_maxVAngle = 0.0f;
-        int m_layers = 0;
-        int m_numberOfIncrements = 0;
+        unsigned int m_layers = 0;
+        unsigned int m_numberOfIncrements = 0;
         float m_maxRange = 0.0f;
     };
 } // namespace ROS2

--- a/Code/Source/Lidar/LidarTemplateUtils.cpp
+++ b/Code/Source/Lidar/LidarTemplateUtils.cpp
@@ -52,11 +52,9 @@ namespace ROS2
     }
 
     // TODO - lidars in reality do not have uniform distributions - populating needs to be defined per model
-    AZStd::vector<AZ::Vector3> LidarTemplateUtils::PopulateRayDirections(LidarTemplate::LidarModel model,
+    AZStd::vector<AZ::Vector3> LidarTemplateUtils::PopulateRayDirections(const LidarTemplate& lidarTemplate,
                                                                          const AZ::Vector3& rootRotation)
     {
-        auto lidarTemplate = GetTemplate(model);
-
         const float minVertAngle = AZ::DegToRad(lidarTemplate.m_minVAngle);
         const float maxVertAngle = AZ::DegToRad(lidarTemplate.m_maxVAngle);
         const float minHorAngle = AZ::DegToRad(lidarTemplate.m_minHAngle);

--- a/Code/Source/Lidar/LidarTemplateUtils.h
+++ b/Code/Source/Lidar/LidarTemplateUtils.h
@@ -24,7 +24,7 @@ namespace ROS2
         //! @param model Lidar model to use. Note that different models will produce different number of rays.
         //! @param rootRotation Root rotation as Euler angles in radians.
         //! @return All ray directions which can be used to perform ray-casting simulation of lidar operation.
-        static AZStd::vector<AZ::Vector3> PopulateRayDirections(LidarTemplate::LidarModel model,
+        static AZStd::vector<AZ::Vector3> PopulateRayDirections(const LidarTemplate& lidarTemplate,
                                                                 const AZ::Vector3& rootRotation);
     };
 } // namespace ROS2

--- a/Code/Source/Lidar/ROS2LidarSensorComponent.cpp
+++ b/Code/Source/Lidar/ROS2LidarSensorComponent.cpp
@@ -17,6 +17,7 @@
 #include <Atom/RPI.Public/AuxGeom/AuxGeomFeatureProcessorInterface.h>
 #include <Atom/RPI.Public/RPISystemInterface.h>
 #include <Atom/RPI.Public/Scene.h>
+#include <AzFramework/Physics/PhysicsSystem.h>
 
 namespace ROS2
 {
@@ -33,7 +34,7 @@ namespace ROS2
             serialize->Class<ROS2LidarSensorComponent, ROS2SensorComponent>()
                 ->Version(1)
                 ->Field("lidarModel", &ROS2LidarSensorComponent::m_lidarModel)
-                ->Field("selfCollisionEntityId", &ROS2LidarSensorComponent::m_selfColliderEntityId)
+                ->Field("LidarTransparentEntityId", &ROS2LidarSensorComponent::m_lidarTransparentEntityId)
                 ;
 
             if (AZ::EditContext* ec = serialize->GetEditContext())
@@ -44,8 +45,9 @@ namespace ROS2
                     ->DataElement(AZ::Edit::UIHandlers::ComboBox, &ROS2LidarSensorComponent::m_lidarModel, "Lidar Model", "Lidar model")
                         ->EnumAttribute(LidarTemplate::LidarModel::Generic3DLidar, "Generic Lidar")
                         // TODO - show lidar template field values (read only) - see Reflect for LidarTemplate
-                    ->DataElement(AZ::Edit::UIHandlers::EntityId, &ROS2LidarSensorComponent::m_selfColliderEntityId, "Self collision Entity",
-                                  "Entity to be transparent for the lidar. If not set, use this entity")
+                    ->DataElement(AZ::Edit::UIHandlers::EntityId, &ROS2LidarSensorComponent::m_lidarTransparentEntityId,
+                                  "Lidar-transparent Entity",
+                                  "Entity to be transparent for the lidar. If not set, use this component's entity")
                     ;
             }
         }
@@ -82,9 +84,23 @@ namespace ROS2
         }
     }
 
+    void ROS2LidarSensorComponent::SetPhysicsScene()
+    {
+        auto* physicsSystem = AZ::Interface<AzPhysics::SystemInterface>::Get();
+        auto foundBody = physicsSystem->FindAttachedBodyHandleFromEntityId(GetEntityId());
+        auto lidarPhysicsSceneHandle = foundBody.first;
+        if (foundBody.first == AzPhysics::InvalidSceneHandle)
+        {
+            auto* sceneInterface = AZ::Interface<AzPhysics::SceneInterface>::Get();
+            lidarPhysicsSceneHandle = sceneInterface->GetSceneHandle(AzPhysics::DefaultPhysicsSceneName);
+        }
+
+        AZ_Assert(lidarPhysicsSceneHandle != AzPhysics::InvalidSceneHandle, "Invalid physics scene handle for entity");
+        m_lidarRaycaster.SetRaycasterScene(lidarPhysicsSceneHandle);
+    }
+
     void ROS2LidarSensorComponent::Activate()
     {
-        ROS2SensorComponent::Activate();
         auto ros2Node = ROS2Interface::Get()->GetNode();
         AZ_Assert(m_sensorConfiguration.m_publishersConfigurations.size() == 1, "Invalid configuration of publishers for lidar sensor");
 
@@ -92,20 +108,22 @@ namespace ROS2
         AZStd::string fullTopic = ROS2Names::GetNamespacedName(GetNamespace(), publisherConfig.m_topic);
         m_pointCloudPublisher = ros2Node->create_publisher<sensor_msgs::msg::PointCloud2>(fullTopic.data(), publisherConfig.GetQoS());
 
+        SetPhysicsScene();
         if (m_sensorConfiguration.m_visualise)
         {
-            auto defaultScene = AZ::RPI::Scene::GetSceneForEntityId(GetEntityId());
-            m_drawQueue = AZ::RPI::AuxGeomFeatureProcessorInterface::GetDrawQueueForScene(defaultScene);
+            auto* entityScene = AZ::RPI::Scene::GetSceneForEntityId(GetEntityId());
+            m_drawQueue = AZ::RPI::AuxGeomFeatureProcessorInterface::GetDrawQueueForScene(entityScene);
         }
 
-        if (m_selfColliderEntityId.IsValid())
+        if (m_lidarTransparentEntityId.IsValid())
         {
-            m_lidarRaycaster.setSelfColliderEntity(m_selfColliderEntityId);
+            m_lidarRaycaster.setLidarTransparentEntity(m_lidarTransparentEntityId);
         } 
         else 
         {
-            m_lidarRaycaster.setSelfColliderEntity(GetEntityId());
+            m_lidarRaycaster.setLidarTransparentEntity(GetEntityId());
         }
+        ROS2SensorComponent::Activate();
     }
 
     void ROS2LidarSensorComponent::Deactivate()

--- a/Code/Source/Lidar/ROS2LidarSensorComponent.h
+++ b/Code/Source/Lidar/ROS2LidarSensorComponent.h
@@ -9,6 +9,7 @@
 
 #include "Lidar/LidarRaycaster.h"
 #include "Lidar/LidarTemplate.h"
+#include "Lidar/LidarTemplateUtils.h"
 #include "Sensor/ROS2SensorComponent.h"
 #include <AzCore/Serialization/SerializeContext.h>
 #include <Atom/RPI.Public/AuxGeom/AuxGeomDraw.h>
@@ -38,7 +39,11 @@ namespace ROS2
         void Visualise() override;
         void SetPhysicsScene();
 
+        AZ::Crc32 OnLidarModelSelected();
+        bool IsConfigurationVisible() const;
+
         LidarTemplate::LidarModel m_lidarModel = LidarTemplate::Generic3DLidar;
+        LidarTemplate m_lidarParameters = LidarTemplateUtils::GetTemplate(LidarTemplate::Generic3DLidar);
         LidarRaycaster m_lidarRaycaster;
         std::shared_ptr<rclcpp::Publisher<sensor_msgs::msg::PointCloud2>> m_pointCloudPublisher;
 

--- a/Code/Source/Lidar/ROS2LidarSensorComponent.h
+++ b/Code/Source/Lidar/ROS2LidarSensorComponent.h
@@ -36,6 +36,7 @@ namespace ROS2
     private:
         void FrequencyTick() override;
         void Visualise() override;
+        void SetPhysicsScene();
 
         LidarTemplate::LidarModel m_lidarModel = LidarTemplate::Generic3DLidar;
         LidarRaycaster m_lidarRaycaster;
@@ -47,7 +48,7 @@ namespace ROS2
 
         AZStd::vector<AZ::Vector3> m_lastScanResults;
 
-        // EntityId for self collision filter
-        AZ::EntityId m_selfColliderEntityId;
+        // EntityId to ignore in lidar simulation (e.g. do not detect lidar own physical collider)
+        AZ::EntityId m_lidarTransparentEntityId;
     };
 }  // namespace ROS2

--- a/Code/Source/Lidar/ROS2LidarSensorComponent.h
+++ b/Code/Source/Lidar/ROS2LidarSensorComponent.h
@@ -46,5 +46,8 @@ namespace ROS2
         AZ::RPI::AuxGeomDrawPtr m_drawQueue;
 
         AZStd::vector<AZ::Vector3> m_lastScanResults;
+
+        // EntityId for self collision filter
+        AZ::EntityId m_selfColliderEntityId;
     };
 }  // namespace ROS2

--- a/Code/Source/RobotControl/RobotControl.h
+++ b/Code/Source/RobotControl/RobotControl.h
@@ -76,7 +76,9 @@ namespace ROS2
             if (m_controlConfiguration.m_broadcastBusMode)
             {
                 BroadcastBus(message);
-            } else {
+            } 
+            else
+            {
                 ApplyControl(message);
             }
         };

--- a/Code/Source/Sensor/ROS2SensorComponent.cpp
+++ b/Code/Source/Sensor/ROS2SensorComponent.cpp
@@ -77,15 +77,14 @@ namespace ROS2
         // TODO - add range validation (Attributes?)
         auto frameTime = frequency == 0 ? 1 : 1 / frequency;
 
-        static float elapsed = 0;
-        elapsed += deltaTime;
-        if (elapsed < frameTime)
+        m_timeElapsedSinceLastTick += deltaTime;
+        if (m_timeElapsedSinceLastTick < frameTime)
             return;
 
-        elapsed -= frameTime;
+        m_timeElapsedSinceLastTick -= frameTime;
         if (deltaTime > frameTime)
         {   // Frequency higher than possible, not catching up, just keep going with each frame.
-            elapsed = 0;
+            m_timeElapsedSinceLastTick = 0.0f;
         }
 
         // Note that sensor frequency can be limited by simulation tick rate (if higher sensor Hz is desired).

--- a/Code/Source/Sensor/ROS2SensorComponent.h
+++ b/Code/Source/Sensor/ROS2SensorComponent.h
@@ -47,5 +47,7 @@ namespace ROS2
         //! For example, draw points or rays for a lidar, viewport for a camera, etc.
         //! Visualisation can be turned on or off in SensorConfiguration.
         virtual void Visualise() { };
+
+        float m_timeElapsedSinceLastTick = 0.0f;
     };
 }  // namespace ROS2


### PR DESCRIPTION
- Generic Lidar now allows customization (as intended) of parameters in the Editor
- Lidars are now not bound to the default scene, instead, they take the owning Entity's scene.
- Lidars can now have a filtered (lidar-transparent) object. By default, it is their own entity. This prevent lidar from detecting only the inside of own box model.
- Some prefab improvements.
- Bugfix to frequency handling with OnTIck - replaced debug static with a member