### PR TITLE
Changed root frame to odom (#86)

### DIFF
--- a/Code/Source/Frame/ROS2FrameComponent.cpp
+++ b/Code/Source/Frame/ROS2FrameComponent.cpp
@@ -54,7 +54,7 @@ namespace ROS2
     const char* ROS2FrameComponent::GetGlobalFrameName()
     {
         // TODO - parametrize this (typically: "odom", "world" and sometimes "map")
-        return "odom";
+        return "odom"; // Odometry frame: https://www.ros.org/reps/rep-0105.html#odom
     }
 
     bool ROS2FrameComponent::IsTopLevel() const

--- a/Code/Source/Frame/ROS2FrameComponent.cpp
+++ b/Code/Source/Frame/ROS2FrameComponent.cpp
@@ -54,7 +54,7 @@ namespace ROS2
     const char* ROS2FrameComponent::GetGlobalFrameName()
     {
         // TODO - parametrize this (typically: "odom", "world" and sometimes "map")
-        return "world";
+        return "odom";
     }
 
     bool ROS2FrameComponent::IsTopLevel() const


### PR DESCRIPTION
Change the global frame to "odom".
- This leaves the "odom"->"map" transformation to the navigation stack. This is how we want it for the demos and most use-cases.
- Previous value was only good for visualisation in RViz2 without the stack.

Note that the desired solution is specified here: https://github.com/RobotecAI/o3de-ros2-gem/issues/22
