### PR TITLE
Robot spawner

### DIFF
--- a/Code/CMakeLists.txt
+++ b/Code/CMakeLists.txt
@@ -35,7 +35,7 @@ ly_add_target(
             Gem::Atom_Component_DebugCamera.Static
 )
 
-target_depends_on_ros2_packages(ROS2.Static rclcpp builtin_interfaces std_msgs sensor_msgs urdfdom tf2_ros)
+target_depends_on_ros2_packages(ROS2.Static rclcpp builtin_interfaces std_msgs sensor_msgs urdfdom tf2_ros o3de_spawning_interface_srvs )
 
 ly_add_target(
     NAME ROS2.API HEADERONLY

--- a/Code/CMakeLists.txt
+++ b/Code/CMakeLists.txt
@@ -35,7 +35,7 @@ ly_add_target(
             Gem::Atom_Component_DebugCamera.Static
 )
 
-target_depends_on_ros2_packages(ROS2.Static rclcpp builtin_interfaces std_msgs sensor_msgs urdfdom tf2_ros o3de_spawning_interface_srvs )
+target_depends_on_ros2_packages(ROS2.Static rclcpp builtin_interfaces std_msgs sensor_msgs urdfdom tf2_ros gazebo_msgs)
 
 ly_add_target(
     NAME ROS2.API HEADERONLY

--- a/Code/Source/ROS2ModuleInterface.h
+++ b/Code/Source/ROS2ModuleInterface.h
@@ -12,7 +12,6 @@
 #include "GNSS/ROS2GNSSSensorComponent.h"
 #include "Imu/ROS2ImuSensorComponent.h"
 #include "Lidar/ROS2LidarSensorComponent.h"
-#include "Spawner/ROS2SpawnerComponent.h"
 #include "ROS2SystemComponent.h"
 #include "RobotControl/ROS2RobotControlComponent.h"
 #include "RobotImporter/ROS2RobotImporterSystemComponent.h"

--- a/Code/Source/ROS2ModuleInterface.h
+++ b/Code/Source/ROS2ModuleInterface.h
@@ -12,6 +12,7 @@
 #include "GNSS/ROS2GNSSSensorComponent.h"
 #include "Imu/ROS2ImuSensorComponent.h"
 #include "Lidar/ROS2LidarSensorComponent.h"
+#include "Spawner/ROS2SpawnerComponent.h"
 #include "ROS2SystemComponent.h"
 #include "RobotControl/ROS2RobotControlComponent.h"
 #include "RobotImporter/ROS2RobotImporterSystemComponent.h"
@@ -42,7 +43,8 @@ namespace ROS2
                   ROS2LidarSensorComponent::CreateDescriptor(),
                   ROS2FrameComponent::CreateDescriptor(),
                   ROS2RobotControlComponent::CreateDescriptor(),
-                  ROS2CameraSensorComponent::CreateDescriptor() });
+                  ROS2CameraSensorComponent::CreateDescriptor(),
+                  ROS2SpawnerComponent::CreateDescriptor() });
         }
 
         //! Add required SystemComponents to the SystemEntity.

--- a/Code/Source/ROS2ModuleInterface.h
+++ b/Code/Source/ROS2ModuleInterface.h
@@ -16,6 +16,7 @@
 #include "ROS2SystemComponent.h"
 #include "RobotControl/ROS2RobotControlComponent.h"
 #include "RobotImporter/ROS2RobotImporterSystemComponent.h"
+#include "Spawner/ROS2SpawnerComponent.h"
 #include <AzCore/Memory/SystemAllocator.h>
 #include <AzCore/Module/Module.h>
 

--- a/Code/Source/Spawner/ROS2SpawnerComponent.cpp
+++ b/Code/Source/Spawner/ROS2SpawnerComponent.cpp
@@ -7,10 +7,10 @@
  */
 
 #include "ROS2SpawnerComponent.h"
-#include <AzCore/Serialization/EditContext.h>
 #include <AzCore/Math/Quaternion.h>
-#include <AzToolsFramework/Entity/EditorEntityHelpers.h>
+#include <AzCore/Serialization/EditContext.h>
 #include <AzFramework/Components/TransformComponent.h>
+#include <AzToolsFramework/Entity/EditorEntityHelpers.h>
 
 namespace ROS2
 {
@@ -19,14 +19,11 @@ namespace ROS2
         auto ros2Node = ROS2Interface::Get()->GetNode();
 
         m_get_names_service = ros2Node->create_service<o3de_spawning_interface_srvs::srv::GetAvailableSpawnableNames>(
-                "get_available_spawnable_names",
-                std::bind( &ROS2SpawnerComponent::GetAvailableSpawnableNames, this, AZStd::placeholders::_1, AZStd::placeholders::_2 )
-        );
+            "get_available_spawnable_names",
+            std::bind(&ROS2SpawnerComponent::GetAvailableSpawnableNames, this, AZStd::placeholders::_1, AZStd::placeholders::_2));
 
         m_spawn_service = ros2Node->create_service<o3de_spawning_interface_srvs::srv::SpawnRobot>(
-                "spawn_robot",
-                std::bind( &ROS2SpawnerComponent::SpawnRobot, this, AZStd::placeholders::_1, AZStd::placeholders::_2 )
-        );
+            "spawn_robot", std::bind(&ROS2SpawnerComponent::SpawnRobot, this, AZStd::placeholders::_1, AZStd::placeholders::_2));
     }
 
     void ROS2SpawnerComponent::Deactivate()
@@ -37,62 +34,67 @@ namespace ROS2
     {
         if (AZ::SerializeContext* serialize = azrtti_cast<AZ::SerializeContext*>(context))
         {
-            serialize->Class<ROS2SpawnerComponent, AZ::Component>()->Version(1)
-                ->Field("Spawner", &ROS2SpawnerComponent::m_spawnables);
+            serialize->Class<ROS2SpawnerComponent, AZ::Component>()->Version(1)->Field("Spawner", &ROS2SpawnerComponent::m_spawnables);
 
             if (AZ::EditContext* ec = serialize->GetEditContext())
             {
                 ec->Class<ROS2SpawnerComponent>("ROS2 Spawner", "Spawner component")
-                        ->ClassElement(AZ::Edit::ClassElements::EditorData, "Allows spawning")
-                        ->Attribute(AZ::Edit::Attributes::AppearsInAddComponentMenu, AZ_CRC("Game"))
-                        ->DataElement(
-                                AZ::Edit::UIHandlers::EntityId,
-                                &ROS2SpawnerComponent::m_spawnables,
-                                "Spawnable",
-                                "Spawnable");
+                    ->ClassElement(AZ::Edit::ClassElements::EditorData, "Allows spawning")
+                    ->Attribute(AZ::Edit::Attributes::AppearsInAddComponentMenu, AZ_CRC("Game"))
+                    ->DataElement(AZ::Edit::UIHandlers::EntityId, &ROS2SpawnerComponent::m_spawnables, "Spawnable", "Spawnable");
             }
         }
     }
 
-    void ROS2SpawnerComponent::GetAvailableSpawnableNames(const std::shared_ptr<o3de_spawning_interface_srvs::srv::GetAvailableSpawnableNames::Request> request, std::shared_ptr<o3de_spawning_interface_srvs::srv::GetAvailableSpawnableNames::Response> response)
+    void ROS2SpawnerComponent::GetAvailableSpawnableNames(
+        const std::shared_ptr<o3de_spawning_interface_srvs::srv::GetAvailableSpawnableNames::Request> request,
+        std::shared_ptr<o3de_spawning_interface_srvs::srv::GetAvailableSpawnableNames::Response> response)
     {
-        for( const auto& spawnable : m_spawnables )
+        for (const auto& spawnable : m_spawnables)
         {
-            response->names.emplace_back( spawnable.GetHint().c_str() );
+            response->names.emplace_back(spawnable.GetHint().c_str());
         }
     }
 
-    void ROS2SpawnerComponent::SpawnRobot(const std::shared_ptr<o3de_spawning_interface_srvs::srv::SpawnRobot::Request> request, std::shared_ptr<o3de_spawning_interface_srvs::srv::SpawnRobot::Response> response)
+    void ROS2SpawnerComponent::SpawnRobot(
+        const std::shared_ptr<o3de_spawning_interface_srvs::srv::SpawnRobot::Request> request,
+        std::shared_ptr<o3de_spawning_interface_srvs::srv::SpawnRobot::Response> response)
     {
-        auto key = AZStd::string(request->robot_name.c_str(), request->robot_name.size() );
+        auto key = AZStd::string(request->robot_name.c_str(), request->robot_name.size());
 
-        auto spawnable = std::find_if( m_spawnables.begin(), m_spawnables.end(), [key](auto spwn) { return spwn.GetHint() == key; } );
-
-        if(  spawnable != m_spawnables.end() )
-        {
-            if( m_tickets.find( key ) == m_tickets.end() )
+        auto spawnable = std::find_if(
+            m_spawnables.begin(),
+            m_spawnables.end(),
+            [key](auto spwn)
             {
-                // if a ticket for this spawnable was not created but the spawnable name is correct, create the ticket and then use it to spawn an entity
-                m_tickets.insert( { spawnable->GetHint(), AzFramework::EntitySpawnTicket(*spawnable) });
+                return spwn.GetHint() == key;
+            });
+
+        if (spawnable != m_spawnables.end())
+        {
+            if (m_tickets.find(key) == m_tickets.end())
+            {
+                // if a ticket for this spawnable was not created but the spawnable name is correct, create the ticket and then use it to
+                // spawn an entity
+                m_tickets.insert({ spawnable->GetHint(), AzFramework::EntitySpawnTicket(*spawnable) });
             }
 
             auto spawner = AZ::Interface<AzFramework::SpawnableEntitiesDefinition>::Get();
 
             AzFramework::SpawnAllEntitiesOptionalArgs optionalArgs;
 
-            optionalArgs.m_preInsertionCallback = [this, position = request->position](auto id, auto view){
+            optionalArgs.m_preInsertionCallback = [this, position = request->position](auto id, auto view)
+            {
                 this->pre_spawn(
-                        id,
-                        view,
-                        AZ::Transform(
-                            AZ::Vector3(position.position.x, position.position.y, position.position.z),
-                            AZ::Quaternion(position.orientation.x, position.orientation.y, position.orientation.z, position.orientation.w),
-                            1.0f
-                        )
-                );
+                    id,
+                    view,
+                    AZ::Transform(
+                        AZ::Vector3(position.position.x, position.position.y, position.position.z),
+                        AZ::Quaternion(position.orientation.x, position.orientation.y, position.orientation.z, position.orientation.w),
+                        1.0f));
             };
 
-            spawner->SpawnAllEntities( m_tickets.at(key), optionalArgs );
+            spawner->SpawnAllEntities(m_tickets.at(key), optionalArgs);
 
             response->result = true;
             return;
@@ -101,13 +103,14 @@ namespace ROS2
         response->result = false;
     }
 
-    void ROS2SpawnerComponent::pre_spawn(AzFramework::EntitySpawnTicket::Id id, AzFramework::SpawnableEntityContainerView view, const AZ::Transform& transform)
+    void ROS2SpawnerComponent::pre_spawn(
+        AzFramework::EntitySpawnTicket::Id id, AzFramework::SpawnableEntityContainerView view, const AZ::Transform& transform)
     {
         AZ::Entity* root = *view.begin();
 
         auto* transformInterface_ = root->FindComponent<AzFramework::TransformComponent>();
 
-        transformInterface_->SetWorldTM( transform );
+        transformInterface_->SetWorldTM(transform);
     }
 
 } // namespace ROS2

--- a/Code/Source/Spawner/ROS2SpawnerComponent.cpp
+++ b/Code/Source/Spawner/ROS2SpawnerComponent.cpp
@@ -47,28 +47,19 @@ namespace ROS2
     }
 
     void ROS2SpawnerComponent::GetAvailableSpawnableNames(
-        const std::shared_ptr<o3de_spawning_interface_srvs::srv::GetAvailableSpawnableNames::Request> request,
-        std::shared_ptr<o3de_spawning_interface_srvs::srv::GetAvailableSpawnableNames::Response> response)
+        const GetAvailableSpawnableNamesRequest request, GetAvailableSpawnableNamesResponse response)
     {
         for (const auto& spawnable : m_spawnables)
         {
-            response->names.emplace_back(spawnable.GetHint().c_str());
+            response->names.emplace_back(spawnable.first.c_str());
         }
     }
 
-    void ROS2SpawnerComponent::SpawnRobot(
-        const std::shared_ptr<o3de_spawning_interface_srvs::srv::SpawnRobot::Request> request,
-        std::shared_ptr<o3de_spawning_interface_srvs::srv::SpawnRobot::Response> response)
+    void ROS2SpawnerComponent::SpawnRobot(const SpawnRobotRequest request, SpawnRobotResponse response)
     {
-        auto key = AZStd::string(request->robot_name.c_str(), request->robot_name.size());
+        const AZStd::string key(request->robot_name.c_str(), request->robot_name.size());
 
-        auto spawnable = std::find_if(
-            m_spawnables.begin(),
-            m_spawnables.end(),
-            [key](auto spwn)
-            {
-                return spwn.GetHint() == key;
-            });
+        auto spawnable = m_spawnables.find(key);
 
         if (spawnable != m_spawnables.end())
         {
@@ -76,7 +67,7 @@ namespace ROS2
             {
                 // if a ticket for this spawnable was not created but the spawnable name is correct, create the ticket and then use it to
                 // spawn an entity
-                m_tickets.insert({ spawnable->GetHint(), AzFramework::EntitySpawnTicket(*spawnable) });
+                m_tickets.emplace(spawnable->first, AzFramework::EntitySpawnTicket(spawnable->second));
             }
 
             auto spawner = AZ::Interface<AzFramework::SpawnableEntitiesDefinition>::Get();

--- a/Code/Source/Spawner/ROS2SpawnerComponent.cpp
+++ b/Code/Source/Spawner/ROS2SpawnerComponent.cpp
@@ -1,0 +1,84 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#include "ROS2SpawnerComponent.h"
+#include <AzCore/Serialization/EditContext.h>
+#include <AzToolsFramework/Entity/EditorEntityHelpers.h>
+
+namespace ROS2
+{
+    void ROS2SpawnerComponent::Activate()
+    {
+        auto ros2Node = ROS2Interface::Get()->GetNode();
+
+        get_names_service = ros2Node->create_service<o3de_spawning_interface_srvs::srv::GetAvailableSpawnableNames>(
+                "get_available_spawnable_names",
+                std::bind( &ROS2SpawnerComponent::GetAvailableSpawnableNames, this, AZStd::placeholders::_1, AZStd::placeholders::_2 )
+                );
+
+        spawn_service = ros2Node->create_service<o3de_spawning_interface_srvs::srv::SpawnRobot>(
+                "spawn_robot",
+                std::bind( &ROS2SpawnerComponent::SpawnRobot, this, AZStd::placeholders::_1, AZStd::placeholders::_2 )
+                );
+    }
+
+    void ROS2SpawnerComponent::Deactivate()
+    {
+    }
+
+    void ROS2SpawnerComponent::Reflect(AZ::ReflectContext* context)
+    {
+        if (AZ::SerializeContext* serialize = azrtti_cast<AZ::SerializeContext*>(context))
+        {
+            serialize->Class<ROS2SpawnerComponent, AZ::Component>()->Version(1)
+                ->Field("Spawner", &ROS2SpawnerComponent::m_spawnables);
+
+            if (AZ::EditContext* ec = serialize->GetEditContext())
+            {
+                ec->Class<ROS2SpawnerComponent>("ROS2 Spawner", "Spawner component")
+                        ->ClassElement(AZ::Edit::ClassElements::EditorData, "Allows spawning")
+                        ->Attribute(AZ::Edit::Attributes::AppearsInAddComponentMenu, AZ_CRC("Game"))
+                        ->DataElement(
+                                AZ::Edit::UIHandlers::EntityId,
+                                &ROS2SpawnerComponent::m_spawnables,
+                                "Spawnable",
+                                "Spawnable");
+            }
+        }
+    }
+
+    void ROS2SpawnerComponent::GetAvailableSpawnableNames(const std::shared_ptr<o3de_spawning_interface_srvs::srv::GetAvailableSpawnableNames::Request> request, std::shared_ptr<o3de_spawning_interface_srvs::srv::GetAvailableSpawnableNames::Response> response)
+    {
+        for( const auto& spawnable : m_spawnables )
+        {
+            response->names.emplace_back( spawnable.GetHint().c_str() );
+        }
+    }
+
+    void ROS2SpawnerComponent::SpawnRobot(const std::shared_ptr<o3de_spawning_interface_srvs::srv::SpawnRobot::Request> request, std::shared_ptr<o3de_spawning_interface_srvs::srv::SpawnRobot::Response> response)
+    {
+        auto key = AZStd::string(request->robot_name.c_str(), request->robot_name.size() );
+
+        auto spawnable = std::find_if( m_spawnables.begin(), m_spawnables.end(), [key](auto spwn) { return spwn.GetHint() == key; } );
+
+        if(  spawnable != m_spawnables.end() )
+        {
+            if( m_tickets.find( key ) == m_tickets.end() )
+            {
+                // if a ticket for this spawnable was not created but the spawnable name is correct, create the ticket and then use it to spawn an entity
+                m_tickets.insert( { spawnable->GetHint(), AzFramework::EntitySpawnTicket(*spawnable) });
+            }
+
+            auto spawner = AZ::Interface<AzFramework::SpawnableEntitiesDefinition>::Get();
+            spawner->SpawnAllEntities( m_tickets.at(key) );
+            response->result = true;
+        }
+
+        response->result = false;
+    }
+} // namespace ROS2

--- a/Code/Source/Spawner/ROS2SpawnerComponent.cpp
+++ b/Code/Source/Spawner/ROS2SpawnerComponent.cpp
@@ -10,7 +10,8 @@
 #include <AzCore/Math/Quaternion.h>
 #include <AzCore/Serialization/EditContext.h>
 #include <AzFramework/Components/TransformComponent.h>
-#include <AzToolsFramework/Entity/EditorEntityHelpers.h>
+#include <AzToolsFramework/UI/PropertyEditor/PropertyEditorAPI.h>
+#include <ROS2/ROS2Bus.h>
 
 namespace ROS2
 {
@@ -18,30 +19,39 @@ namespace ROS2
     {
         auto ros2Node = ROS2Interface::Get()->GetNode();
 
-        m_get_names_service = ros2Node->create_service<gazebo_msgs::srv::GetWorldProperties>(
+        m_getNamesService = ros2Node->create_service<gazebo_msgs::srv::GetWorldProperties>(
             "get_available_spawnable_names",
-            std::bind(&ROS2SpawnerComponent::GetAvailableSpawnableNames, this, AZStd::placeholders::_1, AZStd::placeholders::_2));
+            [this](const GetAvailableSpawnableNamesRequest request, GetAvailableSpawnableNamesResponse response)
+            {
+                this->GetAvailableSpawnableNames(request, response);
+            });
 
-        m_spawn_service = ros2Node->create_service<gazebo_msgs::srv::SpawnEntity>(
-            "spawn_entity", std::bind(&ROS2SpawnerComponent::SpawnRobot, this, AZStd::placeholders::_1, AZStd::placeholders::_2));
+        m_spawnService = ros2Node->create_service<gazebo_msgs::srv::SpawnEntity>(
+            "spawn_entity",
+            [this](const SpawnEntityRequest request, SpawnEntityResponse response)
+            {
+                this->SpawnEntity(request, response);
+            });
     }
 
     void ROS2SpawnerComponent::Deactivate()
     {
+        m_getNamesService.reset();
+        m_spawnService.reset();
     }
 
     void ROS2SpawnerComponent::Reflect(AZ::ReflectContext* context)
     {
         if (AZ::SerializeContext* serialize = azrtti_cast<AZ::SerializeContext*>(context))
         {
-            serialize->Class<ROS2SpawnerComponent, AZ::Component>()->Version(1)->Field("Spawner", &ROS2SpawnerComponent::m_spawnables);
+            serialize->Class<ROS2SpawnerComponent, AZ::Component>()->Version(1)->Field("Spawnables", &ROS2SpawnerComponent::m_spawnables);
 
             if (AZ::EditContext* ec = serialize->GetEditContext())
             {
                 ec->Class<ROS2SpawnerComponent>("ROS2 Spawner", "Spawner component")
-                    ->ClassElement(AZ::Edit::ClassElements::EditorData, "Allows spawning")
+                    ->ClassElement(AZ::Edit::ClassElements::EditorData, "Manages spawning of robots in configurable locations")
                     ->Attribute(AZ::Edit::Attributes::AppearsInAddComponentMenu, AZ_CRC("Game"))
-                    ->DataElement(AZ::Edit::UIHandlers::EntityId, &ROS2SpawnerComponent::m_spawnables, "Spawnable", "Spawnable");
+                    ->DataElement(AZ::Edit::UIHandlers::EntityId, &ROS2SpawnerComponent::m_spawnables, "Spawnables", "Spawnables");
             }
         }
     }
@@ -55,50 +65,59 @@ namespace ROS2
         }
     }
 
-    void ROS2SpawnerComponent::SpawnRobot(const SpawnEntityRequest request, SpawnEntityResponse response)
+    void ROS2SpawnerComponent::SpawnEntity(const SpawnEntityRequest request, SpawnEntityResponse response)
     {
-        const AZStd::string key(request->name.c_str(), request->name.size());
+        AZStd::string_view key(request->name.c_str(), request->name.size());
 
         auto spawnable = m_spawnables.find(key);
 
-        if (spawnable != m_spawnables.end())
+        if (spawnable == m_spawnables.end())
         {
-            if (m_tickets.find(key) == m_tickets.end())
-            {
-                // if a ticket for this spawnable was not created but the spawnable name is correct, create the ticket and then use it to
-                // spawn an entity
-                m_tickets.emplace(spawnable->first, AzFramework::EntitySpawnTicket(spawnable->second));
-            }
-
-            auto spawner = AZ::Interface<AzFramework::SpawnableEntitiesDefinition>::Get();
-
-            AzFramework::SpawnAllEntitiesOptionalArgs optionalArgs;
-
-            optionalArgs.m_preInsertionCallback = [this, position = request->initial_pose](auto id, auto view)
-            {
-                this->pre_spawn(
-                    id,
-                    view,
-                    AZ::Transform(
-                        AZ::Vector3(position.position.x, position.position.y, position.position.z),
-                        AZ::Quaternion(position.orientation.x, position.orientation.y, position.orientation.z, position.orientation.w),
-                        1.0f));
-            };
-
-            spawner->SpawnAllEntities(m_tickets.at(key), optionalArgs);
-
-            response->success = true;
+            response->success = false;
+            response->status_message = "Requested spawnable name not found";
             return;
         }
 
-        response->success = false;
+        if (!m_tickets.contains(key))
+        {
+            // if a ticket for this spawnable was not created but the spawnable name is correct, create the ticket and then use it to
+            // spawn an entity
+            m_tickets.emplace(spawnable->first, AzFramework::EntitySpawnTicket(spawnable->second));
+        }
+
+        auto spawner = AZ::Interface<AzFramework::SpawnableEntitiesDefinition>::Get();
+
+        AzFramework::SpawnAllEntitiesOptionalArgs optionalArgs;
+
+        optionalArgs.m_preInsertionCallback = [this, position = request->initial_pose](auto id, auto view)
+        {
+            this->PreSpawn(
+                id,
+                view,
+                AZ::Transform(
+                    AZ::Vector3(position.position.x, position.position.y, position.position.z),
+                    AZ::Quaternion(position.orientation.x, position.orientation.y, position.orientation.z, position.orientation.w),
+                    1.0f));
+        };
+
+        spawner->SpawnAllEntities(m_tickets.at(key), optionalArgs);
+
+        response->success = true;
     }
 
-    void ROS2SpawnerComponent::pre_spawn(
-        AzFramework::EntitySpawnTicket::Id id, AzFramework::SpawnableEntityContainerView view, const AZ::Transform& transform)
+    void ROS2SpawnerComponent::PreSpawn(
+        AzFramework::EntitySpawnTicket::Id id [[maybe_unused]],
+        AzFramework::SpawnableEntityContainerView view,
+        const AZ::Transform& transform)
     {
+        if (view.empty())
+        {
+            return;
+        }
+
         AZ::Entity* root = *view.begin();
 
+        // TODO: probably it would be better to use TransformBus here
         auto* transformInterface_ = root->FindComponent<AzFramework::TransformComponent>();
 
         transformInterface_->SetWorldTM(transform);

--- a/Code/Source/Spawner/ROS2SpawnerComponent.h
+++ b/Code/Source/Spawner/ROS2SpawnerComponent.h
@@ -8,9 +8,8 @@
 #pragma once
 
 #include <AzCore/Component/Component.h>
-#include <AzFramework/Spawnable/SpawnableEntitiesInterface.h>
 #include <AzFramework/Spawnable/Spawnable.h>
-#include <Sensor/ROS2SensorComponent.h>
+#include <AzFramework/Spawnable/SpawnableEntitiesInterface.h>
 #include <ROS2SystemComponent.h>
 
 #include <o3de_spawning_interface_srvs/srv/get_available_spawnable_names.hpp>
@@ -20,31 +19,37 @@ namespace ROS2
 {
     //! TODO: doc
     class ROS2SpawnerComponent : public AZ::Component
-        {
-        public:
+    {
+    public:
+        AZ_COMPONENT(ROS2SpawnerComponent, "{5950AC6B-75F3-4E0F-BA5C-17C877013710}", AZ::Component);
 
-            AZ_COMPONENT(ROS2SpawnerComponent, "{5950AC6B-75F3-4E0F-BA5C-17C877013710}", AZ::Component);
+        // AZ::Component interface implementation.
+        ROS2SpawnerComponent() = default;
 
-            // AZ::Component interface implementation.
-            ROS2SpawnerComponent() = default;
-            ~ROS2SpawnerComponent() = default;
+        ~ROS2SpawnerComponent() = default;
 
-            void Activate() override;
-            void Deactivate() override;
+        void Activate() override;
 
-            // Required Reflect function.
-            static void Reflect(AZ::ReflectContext* context);
+        void Deactivate() override;
 
-        private:
-            std::map<AZStd::string, AzFramework::EntitySpawnTicket> m_tickets = {};
-            AZStd::vector<AZ::Data::Asset<AzFramework::Spawnable>> m_spawnables = {};
+        // Required Reflect function.
+        static void Reflect(AZ::ReflectContext* context);
 
-            rclcpp::Service<o3de_spawning_interface_srvs::srv::GetAvailableSpawnableNames>::SharedPtr m_get_names_service;
-            rclcpp::Service<o3de_spawning_interface_srvs::srv::SpawnRobot>::SharedPtr m_spawn_service;
+    private:
+        std::map<AZStd::string, AzFramework::EntitySpawnTicket> m_tickets = {};
+        AZStd::vector<AZ::Data::Asset<AzFramework::Spawnable>> m_spawnables = {};
 
-            void GetAvailableSpawnableNames(const std::shared_ptr<o3de_spawning_interface_srvs::srv::GetAvailableSpawnableNames::Request> request, std::shared_ptr<o3de_spawning_interface_srvs::srv::GetAvailableSpawnableNames::Response> response);
-            void SpawnRobot(const std::shared_ptr<o3de_spawning_interface_srvs::srv::SpawnRobot::Request> request, std::shared_ptr<o3de_spawning_interface_srvs::srv::SpawnRobot::Response> response);
+        rclcpp::Service<o3de_spawning_interface_srvs::srv::GetAvailableSpawnableNames>::SharedPtr m_get_names_service;
+        rclcpp::Service<o3de_spawning_interface_srvs::srv::SpawnRobot>::SharedPtr m_spawn_service;
 
-            void pre_spawn(AzFramework::EntitySpawnTicket::Id, AzFramework::SpawnableEntityContainerView, const AZ::Transform&);
-        };
+        void GetAvailableSpawnableNames(
+            const std::shared_ptr<o3de_spawning_interface_srvs::srv::GetAvailableSpawnableNames::Request> request,
+            std::shared_ptr<o3de_spawning_interface_srvs::srv::GetAvailableSpawnableNames::Response> response);
+
+        void SpawnRobot(
+            const std::shared_ptr<o3de_spawning_interface_srvs::srv::SpawnRobot::Request> request,
+            std::shared_ptr<o3de_spawning_interface_srvs::srv::SpawnRobot::Response> response);
+
+        void pre_spawn(AzFramework::EntitySpawnTicket::Id, AzFramework::SpawnableEntityContainerView, const AZ::Transform&);
+    };
 } // namespace ROS2

--- a/Code/Source/Spawner/ROS2SpawnerComponent.h
+++ b/Code/Source/Spawner/ROS2SpawnerComponent.h
@@ -10,10 +10,9 @@
 #include <AzCore/Component/Component.h>
 #include <AzFramework/Spawnable/Spawnable.h>
 #include <AzFramework/Spawnable/SpawnableEntitiesInterface.h>
-#include <ROS2SystemComponent.h>
-
 #include <gazebo_msgs/srv/get_world_properties.hpp>
 #include <gazebo_msgs/srv/spawn_entity.hpp>
+#include <rclcpp/rclcpp.hpp>
 
 namespace ROS2
 {
@@ -22,7 +21,8 @@ namespace ROS2
     using SpawnEntityRequest = std::shared_ptr<gazebo_msgs::srv::SpawnEntity::Request>;
     using SpawnEntityResponse = std::shared_ptr<gazebo_msgs::srv::SpawnEntity::Response>;
 
-    //! TODO: doc
+    //! Manages robots spawning.
+    //! Allows user to set spawnable prefabs in the Editor and spawn them using ROS2 service during the simulation.
     class ROS2SpawnerComponent : public AZ::Component
     {
     public:
@@ -44,13 +44,13 @@ namespace ROS2
         AZStd::unordered_map<AZStd::string, AZ::Data::Asset<AzFramework::Spawnable>> m_spawnables;
         AZStd::unordered_map<AZStd::string, AzFramework::EntitySpawnTicket> m_tickets;
 
-        rclcpp::Service<gazebo_msgs::srv::GetWorldProperties>::SharedPtr m_get_names_service;
-        rclcpp::Service<gazebo_msgs::srv::SpawnEntity>::SharedPtr m_spawn_service;
+        rclcpp::Service<gazebo_msgs::srv::GetWorldProperties>::SharedPtr m_getNamesService;
+        rclcpp::Service<gazebo_msgs::srv::SpawnEntity>::SharedPtr m_spawnService;
 
         void GetAvailableSpawnableNames(const GetAvailableSpawnableNamesRequest request, GetAvailableSpawnableNamesResponse response);
 
-        void SpawnRobot(const SpawnEntityRequest request, SpawnEntityResponse response);
+        void SpawnEntity(const SpawnEntityRequest request, SpawnEntityResponse response);
 
-        void pre_spawn(AzFramework::EntitySpawnTicket::Id, AzFramework::SpawnableEntityContainerView, const AZ::Transform&);
+        void PreSpawn(AzFramework::EntitySpawnTicket::Id, AzFramework::SpawnableEntityContainerView, const AZ::Transform&);
     };
 } // namespace ROS2

--- a/Code/Source/Spawner/ROS2SpawnerComponent.h
+++ b/Code/Source/Spawner/ROS2SpawnerComponent.h
@@ -12,15 +12,15 @@
 #include <AzFramework/Spawnable/SpawnableEntitiesInterface.h>
 #include <ROS2SystemComponent.h>
 
-#include <o3de_spawning_interface_srvs/srv/get_available_spawnable_names.hpp>
-#include <o3de_spawning_interface_srvs/srv/spawn_robot.hpp>
+#include <gazebo_msgs/srv/get_world_properties.hpp>
+#include <gazebo_msgs/srv/spawn_entity.hpp>
 
 namespace ROS2
 {
-    using GetAvailableSpawnableNamesRequest = std::shared_ptr<o3de_spawning_interface_srvs::srv::GetAvailableSpawnableNames::Request>;
-    using GetAvailableSpawnableNamesResponse = std::shared_ptr<o3de_spawning_interface_srvs::srv::GetAvailableSpawnableNames::Response>;
-    using SpawnRobotRequest = std::shared_ptr<o3de_spawning_interface_srvs::srv::SpawnRobot::Request>;
-    using SpawnRobotResponse = std::shared_ptr<o3de_spawning_interface_srvs::srv::SpawnRobot::Response>;
+    using GetAvailableSpawnableNamesRequest = std::shared_ptr<gazebo_msgs::srv::GetWorldProperties::Request>;
+    using GetAvailableSpawnableNamesResponse = std::shared_ptr<gazebo_msgs::srv::GetWorldProperties::Response>;
+    using SpawnEntityRequest = std::shared_ptr<gazebo_msgs::srv::SpawnEntity::Request>;
+    using SpawnEntityResponse = std::shared_ptr<gazebo_msgs::srv::SpawnEntity::Response>;
 
     //! TODO: doc
     class ROS2SpawnerComponent : public AZ::Component
@@ -44,12 +44,12 @@ namespace ROS2
         AZStd::unordered_map<AZStd::string, AZ::Data::Asset<AzFramework::Spawnable>> m_spawnables;
         AZStd::unordered_map<AZStd::string, AzFramework::EntitySpawnTicket> m_tickets;
 
-        rclcpp::Service<o3de_spawning_interface_srvs::srv::GetAvailableSpawnableNames>::SharedPtr m_get_names_service;
-        rclcpp::Service<o3de_spawning_interface_srvs::srv::SpawnRobot>::SharedPtr m_spawn_service;
+        rclcpp::Service<gazebo_msgs::srv::GetWorldProperties>::SharedPtr m_get_names_service;
+        rclcpp::Service<gazebo_msgs::srv::SpawnEntity>::SharedPtr m_spawn_service;
 
         void GetAvailableSpawnableNames(const GetAvailableSpawnableNamesRequest request, GetAvailableSpawnableNamesResponse response);
 
-        void SpawnRobot(const SpawnRobotRequest request, SpawnRobotResponse response);
+        void SpawnRobot(const SpawnEntityRequest request, SpawnEntityResponse response);
 
         void pre_spawn(AzFramework::EntitySpawnTicket::Id, AzFramework::SpawnableEntityContainerView, const AZ::Transform&);
     };

--- a/Code/Source/Spawner/ROS2SpawnerComponent.h
+++ b/Code/Source/Spawner/ROS2SpawnerComponent.h
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+#pragma once
+
+#include <AzCore/Component/Component.h>
+#include <AzFramework/Spawnable/SpawnableEntitiesInterface.h>
+#include <AzFramework/Spawnable/Spawnable.h>
+#include <Sensor/ROS2SensorComponent.h>
+#include <ROS2SystemComponent.h>
+
+#include <o3de_spawning_interface_srvs/srv/get_available_spawnable_names.hpp>
+#include <o3de_spawning_interface_srvs/srv/spawn_robot.hpp>
+
+namespace ROS2
+{
+    //! TODO: doc
+    class ROS2SpawnerComponent : public AZ::Component
+        {
+        public:
+
+            AZ_COMPONENT(ROS2SpawnerComponent, "{5950AC6B-75F3-4E0F-BA5C-17C877013710}", AZ::Component);
+
+            // AZ::Component interface implementation.
+            ROS2SpawnerComponent() = default;
+            ~ROS2SpawnerComponent() = default;
+
+            void Activate() override;
+            void Deactivate() override;
+
+            // Required Reflect function.
+            static void Reflect(AZ::ReflectContext* context);
+
+        private:
+            std::map<AZStd::string, AzFramework::EntitySpawnTicket> m_tickets = {};
+            AZStd::vector<AZ::Data::Asset<AzFramework::Spawnable>> m_spawnables = {};
+
+            rclcpp::Service<o3de_spawning_interface_srvs::srv::GetAvailableSpawnableNames>::SharedPtr get_names_service;
+            rclcpp::Service<o3de_spawning_interface_srvs::srv::SpawnRobot>::SharedPtr spawn_service;
+
+            void GetAvailableSpawnableNames(const std::shared_ptr<o3de_spawning_interface_srvs::srv::GetAvailableSpawnableNames::Request> request, std::shared_ptr<o3de_spawning_interface_srvs::srv::GetAvailableSpawnableNames::Response> response);
+            void SpawnRobot(const std::shared_ptr<o3de_spawning_interface_srvs::srv::SpawnRobot::Request> request, std::shared_ptr<o3de_spawning_interface_srvs::srv::SpawnRobot::Response> response);
+        };
+} // namespace ROS2

--- a/Code/Source/Spawner/ROS2SpawnerComponent.h
+++ b/Code/Source/Spawner/ROS2SpawnerComponent.h
@@ -17,6 +17,11 @@
 
 namespace ROS2
 {
+    using GetAvailableSpawnableNamesRequest = std::shared_ptr<o3de_spawning_interface_srvs::srv::GetAvailableSpawnableNames::Request>;
+    using GetAvailableSpawnableNamesResponse = std::shared_ptr<o3de_spawning_interface_srvs::srv::GetAvailableSpawnableNames::Response>;
+    using SpawnRobotRequest = std::shared_ptr<o3de_spawning_interface_srvs::srv::SpawnRobot::Request>;
+    using SpawnRobotResponse = std::shared_ptr<o3de_spawning_interface_srvs::srv::SpawnRobot::Response>;
+
     //! TODO: doc
     class ROS2SpawnerComponent : public AZ::Component
     {
@@ -36,19 +41,15 @@ namespace ROS2
         static void Reflect(AZ::ReflectContext* context);
 
     private:
-        std::map<AZStd::string, AzFramework::EntitySpawnTicket> m_tickets = {};
-        AZStd::vector<AZ::Data::Asset<AzFramework::Spawnable>> m_spawnables = {};
+        AZStd::unordered_map<AZStd::string, AZ::Data::Asset<AzFramework::Spawnable>> m_spawnables;
+        AZStd::unordered_map<AZStd::string, AzFramework::EntitySpawnTicket> m_tickets;
 
         rclcpp::Service<o3de_spawning_interface_srvs::srv::GetAvailableSpawnableNames>::SharedPtr m_get_names_service;
         rclcpp::Service<o3de_spawning_interface_srvs::srv::SpawnRobot>::SharedPtr m_spawn_service;
 
-        void GetAvailableSpawnableNames(
-            const std::shared_ptr<o3de_spawning_interface_srvs::srv::GetAvailableSpawnableNames::Request> request,
-            std::shared_ptr<o3de_spawning_interface_srvs::srv::GetAvailableSpawnableNames::Response> response);
+        void GetAvailableSpawnableNames(const GetAvailableSpawnableNamesRequest request, GetAvailableSpawnableNamesResponse response);
 
-        void SpawnRobot(
-            const std::shared_ptr<o3de_spawning_interface_srvs::srv::SpawnRobot::Request> request,
-            std::shared_ptr<o3de_spawning_interface_srvs::srv::SpawnRobot::Response> response);
+        void SpawnRobot(const SpawnRobotRequest request, SpawnRobotResponse response);
 
         void pre_spawn(AzFramework::EntitySpawnTicket::Id, AzFramework::SpawnableEntityContainerView, const AZ::Transform&);
     };

--- a/Code/Source/Spawner/ROS2SpawnerComponent.h
+++ b/Code/Source/Spawner/ROS2SpawnerComponent.h
@@ -39,10 +39,12 @@ namespace ROS2
             std::map<AZStd::string, AzFramework::EntitySpawnTicket> m_tickets = {};
             AZStd::vector<AZ::Data::Asset<AzFramework::Spawnable>> m_spawnables = {};
 
-            rclcpp::Service<o3de_spawning_interface_srvs::srv::GetAvailableSpawnableNames>::SharedPtr get_names_service;
-            rclcpp::Service<o3de_spawning_interface_srvs::srv::SpawnRobot>::SharedPtr spawn_service;
+            rclcpp::Service<o3de_spawning_interface_srvs::srv::GetAvailableSpawnableNames>::SharedPtr m_get_names_service;
+            rclcpp::Service<o3de_spawning_interface_srvs::srv::SpawnRobot>::SharedPtr m_spawn_service;
 
             void GetAvailableSpawnableNames(const std::shared_ptr<o3de_spawning_interface_srvs::srv::GetAvailableSpawnableNames::Request> request, std::shared_ptr<o3de_spawning_interface_srvs::srv::GetAvailableSpawnableNames::Response> response);
             void SpawnRobot(const std::shared_ptr<o3de_spawning_interface_srvs::srv::SpawnRobot::Request> request, std::shared_ptr<o3de_spawning_interface_srvs::srv::SpawnRobot::Response> response);
+
+            void pre_spawn(AzFramework::EntitySpawnTicket::Id, AzFramework::SpawnableEntityContainerView, const AZ::Transform&);
         };
 } // namespace ROS2

--- a/Code/ros2_files.cmake
+++ b/Code/ros2_files.cmake
@@ -69,4 +69,6 @@ set(FILES
     Source/Converters/URDF/ToFBX/UniqueIdGenerator.h
     Source/Converters/URDF/ToFBX/UrdfToFbxConverter.cpp
     Source/Converters/URDF/ToFBX/UrdfToFbxConverter.h
+    Source/Spawner/ROS2SpawnerComponent.h
+    Source/Spawner/ROS2SpawnerComponent.cpp
 )

--- a/README.md
+++ b/README.md
@@ -9,6 +9,8 @@ This Gem enables users to develop robotic simulations through ROS2 tools and com
 * Modern version of ROS 2. We support and tested with:
   * [ROS 2 Galactic](https://docs.ros.org/en/galactic/Installation.html) with Ubuntu 20.04.
   * [ROS 2 Humble](https://docs.ros.org/en/humble/Installation.html) with Ubuntu 22.04.
+  * Additional ROS2 packages required:
+    * gazebo_msgs ( sudo apt install ros-${ROS_DISTRO}-gazebo-msgs)
 
 ## Features
 

--- a/README.md
+++ b/README.md
@@ -9,8 +9,12 @@ This Gem enables users to develop robotic simulations through ROS2 tools and com
 * Modern version of ROS 2. We support and tested with:
   * [ROS 2 Galactic](https://docs.ros.org/en/galactic/Installation.html) with Ubuntu 20.04.
   * [ROS 2 Humble](https://docs.ros.org/en/humble/Installation.html) with Ubuntu 22.04.
-  * Additional ROS2 packages required:
-    * gazebo_msgs ( sudo apt install ros-${ROS_DISTRO}-gazebo-msgs)
+
+#### Additional ros packages required
+
+Replace `<distro>` with ROS 2 distribution name (galactic, humble, ..).
+
+* gazebo_msgs ( sudo apt install ros-${ROS_DISTRO}-gazebo-msgs)
 
 ## Features
 

--- a/docs/guides/ros2-gem.md
+++ b/docs/guides/ros2-gem.md
@@ -23,6 +23,8 @@ You can browse Doxygen-generated documentation on [Gem's GitHub page](https://ro
   - ROS2LidarComponent
 - __Robot control__
   - ROS2RobotControlComponent
+- __Spawner__
+  - ROS2SpawnerComponent
   
 ## The Gem and ROS 2 ecosystem
 
@@ -88,6 +90,15 @@ You can use tools such as [rqt_robot_steering](https://index.ros.org/p/rqt_robot
 
 It is possible to implement your own control mechanisms with this Component.
 
+#### Spawner
+
+`ROS2SpawnerComponent` handles spawning entities during simulation.
+Available spawnables have to be set up as the component's field before the simulation.
+
+During the simulation user can access names of available spawnables and request spawning using ros2 services. GetWorldProperties.srv and SpawnEntity.srv types from gazebo_msgs are used to handle these features.
+
+- Spawning: spawnable name should be passed in request.name and the position of entity in request.initial_pose
+- Available spawnable names access: names of available spawnables are sent in response.model_names
 ### Handling custom ROS 2 dependencies
 
 The ROS 2 Gem will respect your choice of [__sourced__](https://docs.ros.org/en/galactic/Tutorials/Workspace/Creating-A-Workspace.html#source-the-overlay) ROS 2 environment.

--- a/docs/guides/ros2-gem.md
+++ b/docs/guides/ros2-gem.md
@@ -95,10 +95,12 @@ It is possible to implement your own control mechanisms with this Component.
 `ROS2SpawnerComponent` handles spawning entities during simulation.
 Available spawnables have to be set up as the component's field before the simulation.
 
-During the simulation user can access names of available spawnables and request spawning using ros2 services. GetWorldProperties.srv and SpawnEntity.srv types from gazebo_msgs are used to handle these features.
+During the simulation user can access names of available spawnables and request spawning using ros2 services. The names of services are "/get_available_spawnable_names" and "/spawn_entity" respectivly. GetWorldProperties.srv and SpawnEntity.srv types from gazebo_msgs are used to handle these features.
 
 - Spawning: spawnable name should be passed in request.name and the position of entity in request.initial_pose
+  - example call: `ros2 service call /spawn_entity gazebo_msgs/srv/SpawnEntity '{name: 'robot', initial_pose: {position:{ x: 4, y: 4, z: 0.2}, orientation: {x: 0.0, y: 0.0, z: 0.0, w: 1.0}}}'`
 - Available spawnable names access: names of available spawnables are sent in response.model_names
+  - example call: `ros2 service call /get_available_spawnable_names gazebo_msgs/srv/GetWorldProperties`
 ### Handling custom ROS 2 dependencies
 
 The ROS 2 Gem will respect your choice of [__sourced__](https://docs.ros.org/en/galactic/Tutorials/Workspace/Creating-A-Workspace.html#source-the-overlay) ROS 2 environment.


### PR DESCRIPTION
ROS2SpawnerComponent created. It allows spawning robots in a specific place using services from gazebo_msgs.

User has to manually add spawnable file to the Spawner's spawnables list in the Editor before running the simulation.