### PR TITLE
Spawn points provider

### DIFF
--- a/Code/CMakeLists.txt
+++ b/Code/CMakeLists.txt
@@ -29,12 +29,13 @@ ly_add_target(
         PUBLIC
             AZ::AzCore
             AZ::AzFramework
+            AZ::AzToolsFramework
             Gem::Atom_RPI.Public
             Gem::Atom_Feature_Common.Static
             Gem::Atom_Component_DebugCamera.Static
 )
 
-target_depends_on_ros2_packages(ROS2.Static rclcpp builtin_interfaces std_msgs sensor_msgs urdfdom tf2_ros)
+target_depends_on_ros2_packages(ROS2.Static rclcpp builtin_interfaces std_msgs sensor_msgs urdfdom tf2_ros o3de_spawning_interface_srvs )
 
 ly_add_target(
     NAME ROS2.API HEADERONLY

--- a/Code/Source/ROS2ModuleInterface.h
+++ b/Code/Source/ROS2ModuleInterface.h
@@ -16,6 +16,7 @@
 #include "RobotControl/ROS2RobotControlComponent.h"
 #include "Spawner/ROS2SpawnerComponent.h"
 #include "Spawner/ROS2SpawnPointsProviderComponent.h"
+#include "Spawner/SpawnPointComponent.h"
 #include <AzCore/Memory/SystemAllocator.h>
 #include <AzCore/Module/Module.h>
 
@@ -44,7 +45,8 @@ namespace ROS2
                   ROS2RobotControlComponent::CreateDescriptor(),
                   ROS2CameraSensorComponent::CreateDescriptor(),
                   ROS2SpawnerComponent::CreateDescriptor(),
-                  ROS2SpawnPointsProviderComponent::CreateDescriptor() });
+                  ROS2SpawnPointsProviderComponent::CreateDescriptor(),
+                  SpawnPointComponent::CreateDescriptor() });
         }
 
         //! Add required SystemComponents to the SystemEntity.

--- a/Code/Source/ROS2ModuleInterface.h
+++ b/Code/Source/ROS2ModuleInterface.h
@@ -15,6 +15,7 @@
 #include "ROS2SystemComponent.h"
 #include "RobotControl/ROS2RobotControlComponent.h"
 #include "Spawner/ROS2SpawnerComponent.h"
+#include "Spawner/ROS2SpawnPointsProviderComponent.h"
 #include <AzCore/Memory/SystemAllocator.h>
 #include <AzCore/Module/Module.h>
 
@@ -42,7 +43,8 @@ namespace ROS2
                   ROS2FrameComponent::CreateDescriptor(),
                   ROS2RobotControlComponent::CreateDescriptor(),
                   ROS2CameraSensorComponent::CreateDescriptor(),
-                  ROS2SpawnerComponent::CreateDescriptor() });
+                  ROS2SpawnerComponent::CreateDescriptor(),
+                  ROS2SpawnPointsProviderComponent::CreateDescriptor() });
         }
 
         //! Add required SystemComponents to the SystemEntity.

--- a/Code/Source/ROS2ModuleInterface.h
+++ b/Code/Source/ROS2ModuleInterface.h
@@ -12,9 +12,9 @@
 #include "GNSS/ROS2GNSSSensorComponent.h"
 #include "Imu/ROS2ImuSensorComponent.h"
 #include "Lidar/ROS2LidarSensorComponent.h"
-#include "Spawner/ROS2SpawnerComponent.h"
 #include "ROS2SystemComponent.h"
 #include "RobotControl/ROS2RobotControlComponent.h"
+#include "Spawner/ROS2SpawnerComponent.h"
 #include <AzCore/Memory/SystemAllocator.h>
 #include <AzCore/Module/Module.h>
 

--- a/Code/Source/ROS2ModuleInterface.h
+++ b/Code/Source/ROS2ModuleInterface.h
@@ -12,6 +12,7 @@
 #include "GNSS/ROS2GNSSSensorComponent.h"
 #include "Imu/ROS2ImuSensorComponent.h"
 #include "Lidar/ROS2LidarSensorComponent.h"
+#include "Spawner/ROS2SpawnerComponent.h"
 #include "ROS2SystemComponent.h"
 #include "RobotControl/ROS2RobotControlComponent.h"
 #include <AzCore/Memory/SystemAllocator.h>
@@ -40,7 +41,8 @@ namespace ROS2
                   ROS2LidarSensorComponent::CreateDescriptor(),
                   ROS2FrameComponent::CreateDescriptor(),
                   ROS2RobotControlComponent::CreateDescriptor(),
-                  ROS2CameraSensorComponent::CreateDescriptor() });
+                  ROS2CameraSensorComponent::CreateDescriptor(),
+                  ROS2SpawnerComponent::CreateDescriptor() });
         }
 
         //! Add required SystemComponents to the SystemEntity.

--- a/Code/Source/Spawner/ROS2SpawnPointsProviderComponent.cpp
+++ b/Code/Source/Spawner/ROS2SpawnPointsProviderComponent.cpp
@@ -1,0 +1,97 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#include "ROS2SpawnPointsProviderComponent.h"
+#include <AzCore/Serialization/EditContext.h>
+
+#include <geometry_msgs/msg/point.hpp>
+
+namespace ROS2 {
+    ROS2SpawnPointsProviderComponent::ROS2SpawnPointsProviderComponent() {
+        SpawnPointsInterface::Register( this );
+    }
+
+    ROS2SpawnPointsProviderComponent::~ROS2SpawnPointsProviderComponent() {
+        SpawnPointsInterface::Unregister( this );
+    }
+
+    void ROS2SpawnPointsProviderComponent::Activate()
+    {
+        auto ros2Node = ROS2Interface::Get()->GetNode();
+
+        m_is_spawn_point_suitable_service = ros2Node->create_service<o3de_spawning_interface_srvs::srv::IsSpawnPointSuitable>(
+                "is_spawn_point_suitable",
+                std::bind( &ROS2SpawnPointsProviderComponent::IsSpawnPointSuitableSrv, this, AZStd::placeholders::_1, AZStd::placeholders::_2 )
+        );
+
+        m_get_spawn_points_service = ros2Node->create_service<o3de_spawning_interface_srvs::srv::GetSpawnPoints>(
+                "get_spawn_points",
+                std::bind( &ROS2SpawnPointsProviderComponent::GetSpawnPointsSrv, this, AZStd::placeholders::_1, AZStd::placeholders::_2 )
+        );
+    }
+
+    void ROS2SpawnPointsProviderComponent::Deactivate()
+    {
+    }
+
+    void ROS2SpawnPointsProviderComponent::Reflect(AZ::ReflectContext* context)
+    {
+        if (AZ::SerializeContext* serialize = azrtti_cast<AZ::SerializeContext*>(context))
+        {
+            serialize->Class<ROS2SpawnPointsProviderComponent, AZ::Component>()->Version(1);
+
+            if (AZ::EditContext* ec = serialize->GetEditContext())
+            {
+                ec->Class<ROS2SpawnPointsProviderComponent>("ROS2 Spawn Points Provider", "Provides spawn points")
+                        ->ClassElement(AZ::Edit::ClassElements::EditorData, "Provides spawn points")
+                        ->Attribute(AZ::Edit::Attributes::AppearsInAddComponentMenu, AZ_CRC("Game"));
+            }
+        }
+    }
+
+    void ROS2SpawnPointsProviderComponent::GetSpawnPointsSrv(const std::shared_ptr<o3de_spawning_interface_srvs::srv::GetSpawnPoints::Request> request, std::shared_ptr<o3de_spawning_interface_srvs::srv::GetSpawnPoints::Response> response)
+    {
+        std::vector<AZ::Vector3> bounding_box( request->bounding_box.size(), {0, 0, 0});
+        std::transform(request->bounding_box.begin(), request->bounding_box.end(), bounding_box.begin(), [](auto point){ return AZ::Vector3(point.x, point.y, point.z); });
+
+        auto points = GetSpawnPoints( bounding_box );
+
+        response->available_points.insert( response->available_points.end(), points.size(), geometry_msgs::msg::Point() );
+
+        std::transform( points.begin(), points.end(), response->available_points.begin(), []( const auto& point )
+            {
+                auto p = geometry_msgs::msg::Point();
+                p.x = point.GetX();
+                p.y = point.GetY();
+                p.z = point.GetZ();
+                return p;
+            }
+        );
+    }
+
+    void ROS2SpawnPointsProviderComponent::IsSpawnPointSuitableSrv(const std::shared_ptr<o3de_spawning_interface_srvs::srv::IsSpawnPointSuitable::Request> request, std::shared_ptr<o3de_spawning_interface_srvs::srv::IsSpawnPointSuitable::Response> response)
+    {
+        std::vector<AZ::Vector3> bounding_box( request->bounding_box.size(), {0, 0, 0});
+
+        std::transform(request->bounding_box.begin(), request->bounding_box.end(), bounding_box.begin(), [](auto point){ return AZ::Vector3(point.x, point.y, point.z); });
+
+        response->result = IsSpawnPointSuitable( AZ::Vector3( request->center.x, request->center.y, request->center.z ), bounding_box );
+    }
+
+    bool ROS2SpawnPointsProviderComponent::IsSpawnPointSuitable(const AZ::Vector3 &point, const std::vector<AZ::Vector3> &bounding_box) const
+    {
+        //todo: implementation
+        return true;
+    }
+
+    std::vector<AZ::Vector3> ROS2SpawnPointsProviderComponent::GetSpawnPoints(const std::vector<AZ::Vector3> &bounding_box) const
+    {
+        //todo: implementation
+        return std::vector<AZ::Vector3>{ {2,2,0.5} };
+    }
+}

--- a/Code/Source/Spawner/ROS2SpawnPointsProviderComponent.h
+++ b/Code/Source/Spawner/ROS2SpawnPointsProviderComponent.h
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#include <AzCore/Component/Component.h>
+#include <Spawner/SpawnPointsBus.h>
+#include <ROS2SystemComponent.h>
+
+#include <o3de_spawning_interface_srvs/srv/get_spawn_points.hpp>
+#include <o3de_spawning_interface_srvs/srv/is_spawn_point_suitable.hpp>
+
+namespace ROS2
+{
+    class ROS2SpawnPointsProviderComponent:
+            public AZ::Component,
+            public SpawnPointsRequestBus::Handler
+        {
+        public:
+            AZ_COMPONENT(ROS2SpawnPointsProviderComponent, "{199854D3-AEAD-4837-9A02-C07533676CE9}", AZ::Component, SpawnPointsRequestBus::Handler);
+
+            // AZ::Component interface implementation.
+            ROS2SpawnPointsProviderComponent();
+            ~ROS2SpawnPointsProviderComponent();
+
+            void Activate() override;
+            void Deactivate() override;
+
+            // Required Reflect function.
+            static void Reflect(AZ::ReflectContext* context);
+
+            std::vector<AZ::Vector3> GetSpawnPoints(const std::vector<AZ::Vector3> &bounding_box) const override;
+
+            bool IsSpawnPointSuitable(const AZ::Vector3 &point, const std::vector<AZ::Vector3> &bounding_box) const override;
+
+        private:
+            rclcpp::Service<o3de_spawning_interface_srvs::srv::GetSpawnPoints>::SharedPtr m_get_spawn_points_service;
+            rclcpp::Service<o3de_spawning_interface_srvs::srv::IsSpawnPointSuitable>::SharedPtr m_is_spawn_point_suitable_service;
+
+            void GetSpawnPointsSrv(const std::shared_ptr<o3de_spawning_interface_srvs::srv::GetSpawnPoints::Request> request, std::shared_ptr<o3de_spawning_interface_srvs::srv::GetSpawnPoints::Response> response);
+            void IsSpawnPointSuitableSrv(const std::shared_ptr<o3de_spawning_interface_srvs::srv::IsSpawnPointSuitable::Request> request, std::shared_ptr<o3de_spawning_interface_srvs::srv::IsSpawnPointSuitable::Response> response);
+        };
+}

--- a/Code/Source/Spawner/ROS2SpawnPointsProviderComponent.h
+++ b/Code/Source/Spawner/ROS2SpawnPointsProviderComponent.h
@@ -8,10 +8,12 @@
 
 #include <AzCore/Component/Component.h>
 #include <Spawner/SpawnPointsBus.h>
+#include <Spawner/SpawnPointComponent.h>
 #include <ROS2SystemComponent.h>
 
 #include <o3de_spawning_interface_srvs/srv/get_spawn_points.hpp>
 #include <o3de_spawning_interface_srvs/srv/is_spawn_point_suitable.hpp>
+#include <o3de_spawning_interface_srvs/msg/spawn_point.hpp>
 
 namespace ROS2
 {
@@ -32,7 +34,7 @@ namespace ROS2
             // Required Reflect function.
             static void Reflect(AZ::ReflectContext* context);
 
-            std::vector<AZ::Vector3> GetSpawnPoints(const std::vector<AZ::Vector3> &bounding_box) const override;
+            std::vector<SpawnPointInfo> GetSpawnPoints(const std::vector<AZ::Vector3> &bounding_box) const override;
 
             bool IsSpawnPointSuitable(const AZ::Vector3 &point, const std::vector<AZ::Vector3> &bounding_box) const override;
 

--- a/Code/Source/Spawner/ROS2SpawnerComponent.cpp
+++ b/Code/Source/Spawner/ROS2SpawnerComponent.cpp
@@ -7,10 +7,10 @@
  */
 
 #include "ROS2SpawnerComponent.h"
-#include <AzCore/Serialization/EditContext.h>
 #include <AzCore/Math/Quaternion.h>
-#include <AzToolsFramework/Entity/EditorEntityHelpers.h>
+#include <AzCore/Serialization/EditContext.h>
 #include <AzFramework/Components/TransformComponent.h>
+#include <AzToolsFramework/Entity/EditorEntityHelpers.h>
 
 namespace ROS2
 {
@@ -19,14 +19,11 @@ namespace ROS2
         auto ros2Node = ROS2Interface::Get()->GetNode();
 
         m_get_names_service = ros2Node->create_service<o3de_spawning_interface_srvs::srv::GetAvailableSpawnableNames>(
-                "get_available_spawnable_names",
-                std::bind( &ROS2SpawnerComponent::GetAvailableSpawnableNames, this, AZStd::placeholders::_1, AZStd::placeholders::_2 )
-        );
+            "get_available_spawnable_names",
+            std::bind(&ROS2SpawnerComponent::GetAvailableSpawnableNames, this, AZStd::placeholders::_1, AZStd::placeholders::_2));
 
         m_spawn_service = ros2Node->create_service<o3de_spawning_interface_srvs::srv::SpawnRobot>(
-                "spawn_robot",
-                std::bind( &ROS2SpawnerComponent::SpawnRobot, this, AZStd::placeholders::_1, AZStd::placeholders::_2 )
-        );
+            "spawn_robot", std::bind(&ROS2SpawnerComponent::SpawnRobot, this, AZStd::placeholders::_1, AZStd::placeholders::_2));
     }
 
     void ROS2SpawnerComponent::Deactivate()
@@ -37,62 +34,67 @@ namespace ROS2
     {
         if (AZ::SerializeContext* serialize = azrtti_cast<AZ::SerializeContext*>(context))
         {
-            serialize->Class<ROS2SpawnerComponent, AZ::Component>()->Version(1)
-                ->Field("Spawner", &ROS2SpawnerComponent::m_spawnables);
+            serialize->Class<ROS2SpawnerComponent, AZ::Component>()->Version(1)->Field("Spawner", &ROS2SpawnerComponent::m_spawnables);
 
             if (AZ::EditContext* ec = serialize->GetEditContext())
             {
                 ec->Class<ROS2SpawnerComponent>("ROS2 Spawner", "Spawner component")
-                        ->ClassElement(AZ::Edit::ClassElements::EditorData, "Allows spawning")
-                        ->Attribute(AZ::Edit::Attributes::AppearsInAddComponentMenu, AZ_CRC("Game"))
-                        ->DataElement(
-                                AZ::Edit::UIHandlers::EntityId,
-                                &ROS2SpawnerComponent::m_spawnables,
-                                "Spawnable",
-                                "Spawnable");
+                    ->ClassElement(AZ::Edit::ClassElements::EditorData, "Allows spawning")
+                    ->Attribute(AZ::Edit::Attributes::AppearsInAddComponentMenu, AZ_CRC("Game"))
+                    ->DataElement(AZ::Edit::UIHandlers::EntityId, &ROS2SpawnerComponent::m_spawnables, "Spawnable", "Spawnable");
             }
         }
     }
 
-    void ROS2SpawnerComponent::GetAvailableSpawnableNames(const std::shared_ptr<o3de_spawning_interface_srvs::srv::GetAvailableSpawnableNames::Request> request, std::shared_ptr<o3de_spawning_interface_srvs::srv::GetAvailableSpawnableNames::Response> response)
+    void ROS2SpawnerComponent::GetAvailableSpawnableNames(
+        const std::shared_ptr<o3de_spawning_interface_srvs::srv::GetAvailableSpawnableNames::Request> request,
+        std::shared_ptr<o3de_spawning_interface_srvs::srv::GetAvailableSpawnableNames::Response> response)
     {
-        for( const auto& spawnable : m_spawnables )
+        for (const auto& spawnable : m_spawnables)
         {
-            response->names.emplace_back( spawnable.GetHint().c_str() );
+            response->names.emplace_back(spawnable.GetHint().c_str());
         }
     }
 
-    void ROS2SpawnerComponent::SpawnRobot(const std::shared_ptr<o3de_spawning_interface_srvs::srv::SpawnRobot::Request> request, std::shared_ptr<o3de_spawning_interface_srvs::srv::SpawnRobot::Response> response)
+    void ROS2SpawnerComponent::SpawnRobot(
+        const std::shared_ptr<o3de_spawning_interface_srvs::srv::SpawnRobot::Request> request,
+        std::shared_ptr<o3de_spawning_interface_srvs::srv::SpawnRobot::Response> response)
     {
-        auto key = AZStd::string(request->robot_name.c_str(), request->robot_name.size() );
+        auto key = AZStd::string(request->robot_name.c_str(), request->robot_name.size());
 
-        auto spawnable = std::find_if( m_spawnables.begin(), m_spawnables.end(), [key](auto spwn) { return spwn.GetHint() == key; } );
-
-        if(  spawnable != m_spawnables.end() )
-        {
-            if( m_tickets.find( key ) == m_tickets.end() )
+        auto spawnable = std::find_if(
+            m_spawnables.begin(),
+            m_spawnables.end(),
+            [key](auto spwn)
             {
-                // if a ticket for this spawnable was not created but the spawnable name is correct, create the ticket and then use it to spawn an entity
-                m_tickets.insert( { spawnable->GetHint(), AzFramework::EntitySpawnTicket(*spawnable) });
+                return spwn.GetHint() == key;
+            });
+
+        if (spawnable != m_spawnables.end())
+        {
+            if (m_tickets.find(key) == m_tickets.end())
+            {
+                // if a ticket for this spawnable was not created but the spawnable name is correct, create the ticket and then use it to
+                // spawn an entity
+                m_tickets.insert({ spawnable->GetHint(), AzFramework::EntitySpawnTicket(*spawnable) });
             }
 
             auto spawner = AZ::Interface<AzFramework::SpawnableEntitiesDefinition>::Get();
 
             AzFramework::SpawnAllEntitiesOptionalArgs optionalArgs;
 
-            optionalArgs.m_preInsertionCallback = [this, position = request->position](auto id, auto view){
+            optionalArgs.m_preInsertionCallback = [this, position = request->position](auto id, auto view)
+            {
                 this->pre_spawn(
-                        id,
-                        view,
-                        AZ::Transform(
-                            AZ::Vector3(position.position.x, position.position.y, position.position.z),
-                            AZ::Quaternion(position.orientation.x, position.orientation.y, position.orientation.z, position.orientation.w),
-                            1.0f
-                        )
-                );
+                    id,
+                    view,
+                    AZ::Transform(
+                        AZ::Vector3(position.position.x, position.position.y, position.position.z),
+                        AZ::Quaternion(position.orientation.x, position.orientation.y, position.orientation.z, position.orientation.w),
+                        1.0f));
             };
 
-            spawner->SpawnAllEntities( m_tickets.at(key), optionalArgs );
+            spawner->SpawnAllEntities(m_tickets.at(key), optionalArgs);
 
             response->result = true;
             return;
@@ -101,13 +103,14 @@ namespace ROS2
         response->result = false;
     }
 
-    void ROS2SpawnerComponent::pre_spawn(AzFramework::EntitySpawnTicket::Id id, AzFramework::SpawnableEntityContainerView view, const AZ::Transform& transform)
+    void ROS2SpawnerComponent::pre_spawn(
+        AzFramework::EntitySpawnTicket::Id id, AzFramework::SpawnableEntityContainerView view, const AZ::Transform& transform)
     {
         AZ::Entity* root = *view.begin();
 
         auto* transformInterface_ = root->FindComponent<AzFramework::TransformComponent>();
 
-        transformInterface_->SetWorldTM( transform );
+        transformInterface_->SetWorldTM(transform);
     }
 
 } // namespace ROS2

--- a/Code/Source/Spawner/ROS2SpawnerComponent.cpp
+++ b/Code/Source/Spawner/ROS2SpawnerComponent.cpp
@@ -70,6 +70,15 @@ namespace ROS2
                 return spwn.GetHint() == key;
             });
 
+        auto interface = SpawnPointsInterface::Get();
+        auto available = interface->IsSpawnPointSuitable( AZ::Vector3(request->position.position.x, request->position.position.y, request->position.position.z ), {} );
+
+        if( !available )
+        {
+            response->result = false;
+            response->info = "Entity does not fit in the specified place";
+        }
+
         if (spawnable != m_spawnables.end())
         {
             if (m_tickets.find(key) == m_tickets.end())

--- a/Code/Source/Spawner/ROS2SpawnerComponent.cpp
+++ b/Code/Source/Spawner/ROS2SpawnerComponent.cpp
@@ -1,0 +1,84 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#include "ROS2SpawnerComponent.h"
+#include <AzCore/Serialization/EditContext.h>
+#include <AzToolsFramework/Entity/EditorEntityHelpers.h>
+
+namespace ROS2
+{
+    void ROS2SpawnerComponent::Activate()
+    {
+        auto ros2Node = ROS2Interface::Get()->GetNode();
+
+        get_names_service = ros2Node->create_service<o3de_spawning_interface_srvs::srv::GetAvailableSpawnableNames>(
+                "get_available_spawnable_names",
+                std::bind( &ROS2SpawnerComponent::GetAvailableSpawnableNames, this, AZStd::placeholders::_1, AZStd::placeholders::_2 )
+                );
+
+        spawn_service = ros2Node->create_service<o3de_spawning_interface_srvs::srv::SpawnRobot>(
+                "spawn_robot",
+                std::bind( &ROS2SpawnerComponent::SpawnRobot, this, AZStd::placeholders::_1, AZStd::placeholders::_2 )
+                );
+    }
+
+    void ROS2SpawnerComponent::Deactivate()
+    {
+    }
+
+    void ROS2SpawnerComponent::Reflect(AZ::ReflectContext* context)
+    {
+        if (AZ::SerializeContext* serialize = azrtti_cast<AZ::SerializeContext*>(context))
+        {
+            serialize->Class<ROS2SpawnerComponent, AZ::Component>()->Version(1)
+                ->Field("Spawner", &ROS2SpawnerComponent::m_spawnables);
+
+            if (AZ::EditContext* ec = serialize->GetEditContext())
+            {
+                ec->Class<ROS2SpawnerComponent>("ROS2 Spawner", "Spawner component")
+                        ->ClassElement(AZ::Edit::ClassElements::EditorData, "Allows spawning")
+                        ->Attribute(AZ::Edit::Attributes::AppearsInAddComponentMenu, AZ_CRC("Game"))
+                        ->DataElement(
+                                AZ::Edit::UIHandlers::EntityId,
+                                &ROS2SpawnerComponent::m_spawnables,
+                                "Spawnable",
+                                "Spawnable");
+            }
+        }
+    }
+
+    void ROS2SpawnerComponent::GetAvailableSpawnableNames(const std::shared_ptr<o3de_spawning_interface_srvs::srv::GetAvailableSpawnableNames::Request> request, std::shared_ptr<o3de_spawning_interface_srvs::srv::GetAvailableSpawnableNames::Response> response)
+    {
+        for( const auto& spawnable : m_spawnables )
+        {
+            response->names.emplace_back( spawnable.GetHint().c_str() );
+        }
+    }
+
+    void ROS2SpawnerComponent::SpawnRobot(const std::shared_ptr<o3de_spawning_interface_srvs::srv::SpawnRobot::Request> request, std::shared_ptr<o3de_spawning_interface_srvs::srv::SpawnRobot::Response> response)
+    {
+        auto key = AZStd::string(request->robot_name.c_str(), request->robot_name.size() );
+
+        auto spawnable = std::find_if( m_spawnables.begin(), m_spawnables.end(), [key](auto spwn) { return spwn.GetHint() == key; } );
+
+        if(  spawnable != m_spawnables.end() )
+        {
+            if( m_tickets.find( key ) == m_tickets.end() )
+            {
+                // if a ticket for this spawnable was not created but the spawnable name is correct, create the ticket and then use it to spawn an entity
+                m_tickets.insert( { spawnable->GetHint(), AzFramework::EntitySpawnTicket(*spawnable) });
+            }
+
+            auto spawner = AZ::Interface<AzFramework::SpawnableEntitiesDefinition>::Get();
+            spawner->SpawnAllEntities( m_tickets.at(key) );
+            response->result = true;
+        }
+
+        response->result = false;
+    }
+} // namespace ROS2

--- a/Code/Source/Spawner/ROS2SpawnerComponent.h
+++ b/Code/Source/Spawner/ROS2SpawnerComponent.h
@@ -8,9 +8,8 @@
 #pragma once
 
 #include <AzCore/Component/Component.h>
-#include <AzFramework/Spawnable/SpawnableEntitiesInterface.h>
 #include <AzFramework/Spawnable/Spawnable.h>
-#include <Sensor/ROS2SensorComponent.h>
+#include <AzFramework/Spawnable/SpawnableEntitiesInterface.h>
 #include <ROS2SystemComponent.h>
 
 #include <o3de_spawning_interface_srvs/srv/get_available_spawnable_names.hpp>
@@ -20,31 +19,37 @@ namespace ROS2
 {
     //! TODO: doc
     class ROS2SpawnerComponent : public AZ::Component
-        {
-        public:
+    {
+    public:
+        AZ_COMPONENT(ROS2SpawnerComponent, "{5950AC6B-75F3-4E0F-BA5C-17C877013710}", AZ::Component);
 
-            AZ_COMPONENT(ROS2SpawnerComponent, "{5950AC6B-75F3-4E0F-BA5C-17C877013710}", AZ::Component);
+        // AZ::Component interface implementation.
+        ROS2SpawnerComponent() = default;
 
-            // AZ::Component interface implementation.
-            ROS2SpawnerComponent() = default;
-            ~ROS2SpawnerComponent() = default;
+        ~ROS2SpawnerComponent() = default;
 
-            void Activate() override;
-            void Deactivate() override;
+        void Activate() override;
 
-            // Required Reflect function.
-            static void Reflect(AZ::ReflectContext* context);
+        void Deactivate() override;
 
-        private:
-            std::map<AZStd::string, AzFramework::EntitySpawnTicket> m_tickets = {};
-            AZStd::vector<AZ::Data::Asset<AzFramework::Spawnable>> m_spawnables = {};
+        // Required Reflect function.
+        static void Reflect(AZ::ReflectContext* context);
 
-            rclcpp::Service<o3de_spawning_interface_srvs::srv::GetAvailableSpawnableNames>::SharedPtr m_get_names_service;
-            rclcpp::Service<o3de_spawning_interface_srvs::srv::SpawnRobot>::SharedPtr m_spawn_service;
+    private:
+        std::map<AZStd::string, AzFramework::EntitySpawnTicket> m_tickets = {};
+        AZStd::vector<AZ::Data::Asset<AzFramework::Spawnable>> m_spawnables = {};
 
-            void GetAvailableSpawnableNames(const std::shared_ptr<o3de_spawning_interface_srvs::srv::GetAvailableSpawnableNames::Request> request, std::shared_ptr<o3de_spawning_interface_srvs::srv::GetAvailableSpawnableNames::Response> response);
-            void SpawnRobot(const std::shared_ptr<o3de_spawning_interface_srvs::srv::SpawnRobot::Request> request, std::shared_ptr<o3de_spawning_interface_srvs::srv::SpawnRobot::Response> response);
+        rclcpp::Service<o3de_spawning_interface_srvs::srv::GetAvailableSpawnableNames>::SharedPtr m_get_names_service;
+        rclcpp::Service<o3de_spawning_interface_srvs::srv::SpawnRobot>::SharedPtr m_spawn_service;
 
-            void pre_spawn(AzFramework::EntitySpawnTicket::Id, AzFramework::SpawnableEntityContainerView, const AZ::Transform&);
-        };
+        void GetAvailableSpawnableNames(
+            const std::shared_ptr<o3de_spawning_interface_srvs::srv::GetAvailableSpawnableNames::Request> request,
+            std::shared_ptr<o3de_spawning_interface_srvs::srv::GetAvailableSpawnableNames::Response> response);
+
+        void SpawnRobot(
+            const std::shared_ptr<o3de_spawning_interface_srvs::srv::SpawnRobot::Request> request,
+            std::shared_ptr<o3de_spawning_interface_srvs::srv::SpawnRobot::Response> response);
+
+        void pre_spawn(AzFramework::EntitySpawnTicket::Id, AzFramework::SpawnableEntityContainerView, const AZ::Transform&);
+    };
 } // namespace ROS2

--- a/Code/Source/Spawner/ROS2SpawnerComponent.h
+++ b/Code/Source/Spawner/ROS2SpawnerComponent.h
@@ -11,6 +11,7 @@
 #include <AzFramework/Spawnable/Spawnable.h>
 #include <AzFramework/Spawnable/SpawnableEntitiesInterface.h>
 #include <ROS2SystemComponent.h>
+#include <Spawner/SpawnPointsBus.h>
 
 #include <o3de_spawning_interface_srvs/srv/get_available_spawnable_names.hpp>
 #include <o3de_spawning_interface_srvs/srv/spawn_robot.hpp>

--- a/Code/Source/Spawner/ROS2SpawnerComponent.h
+++ b/Code/Source/Spawner/ROS2SpawnerComponent.h
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+#pragma once
+
+#include <AzCore/Component/Component.h>
+#include <AzFramework/Spawnable/SpawnableEntitiesInterface.h>
+#include <AzFramework/Spawnable/Spawnable.h>
+#include <Sensor/ROS2SensorComponent.h>
+#include <ROS2SystemComponent.h>
+
+#include <o3de_spawning_interface_srvs/srv/get_available_spawnable_names.hpp>
+#include <o3de_spawning_interface_srvs/srv/spawn_robot.hpp>
+
+namespace ROS2
+{
+    //! TODO: doc
+    class ROS2SpawnerComponent : public AZ::Component
+        {
+        public:
+
+            AZ_COMPONENT(ROS2SpawnerComponent, "{5950AC6B-75F3-4E0F-BA5C-17C877013710}", AZ::Component);
+
+            // AZ::Component interface implementation.
+            ROS2SpawnerComponent() = default;
+            ~ROS2SpawnerComponent() = default;
+
+            void Activate() override;
+            void Deactivate() override;
+
+            // Required Reflect function.
+            static void Reflect(AZ::ReflectContext* context);
+
+        private:
+            std::map<AZStd::string, AzFramework::EntitySpawnTicket> m_tickets = {};
+            AZStd::vector<AZ::Data::Asset<AzFramework::Spawnable>> m_spawnables = {};
+
+            rclcpp::Service<o3de_spawning_interface_srvs::srv::GetAvailableSpawnableNames>::SharedPtr get_names_service;
+            rclcpp::Service<o3de_spawning_interface_srvs::srv::SpawnRobot>::SharedPtr spawn_service;
+
+            void GetAvailableSpawnableNames(const std::shared_ptr<o3de_spawning_interface_srvs::srv::GetAvailableSpawnableNames::Request> request, std::shared_ptr<o3de_spawning_interface_srvs::srv::GetAvailableSpawnableNames::Response> response);
+            void SpawnRobot(const std::shared_ptr<o3de_spawning_interface_srvs::srv::SpawnRobot::Request> request, std::shared_ptr<o3de_spawning_interface_srvs::srv::SpawnRobot::Response> response);
+        };
+} // namespace ROS2

--- a/Code/Source/Spawner/ROS2SpawnerComponent.h
+++ b/Code/Source/Spawner/ROS2SpawnerComponent.h
@@ -39,10 +39,12 @@ namespace ROS2
             std::map<AZStd::string, AzFramework::EntitySpawnTicket> m_tickets = {};
             AZStd::vector<AZ::Data::Asset<AzFramework::Spawnable>> m_spawnables = {};
 
-            rclcpp::Service<o3de_spawning_interface_srvs::srv::GetAvailableSpawnableNames>::SharedPtr get_names_service;
-            rclcpp::Service<o3de_spawning_interface_srvs::srv::SpawnRobot>::SharedPtr spawn_service;
+            rclcpp::Service<o3de_spawning_interface_srvs::srv::GetAvailableSpawnableNames>::SharedPtr m_get_names_service;
+            rclcpp::Service<o3de_spawning_interface_srvs::srv::SpawnRobot>::SharedPtr m_spawn_service;
 
             void GetAvailableSpawnableNames(const std::shared_ptr<o3de_spawning_interface_srvs::srv::GetAvailableSpawnableNames::Request> request, std::shared_ptr<o3de_spawning_interface_srvs::srv::GetAvailableSpawnableNames::Response> response);
             void SpawnRobot(const std::shared_ptr<o3de_spawning_interface_srvs::srv::SpawnRobot::Request> request, std::shared_ptr<o3de_spawning_interface_srvs::srv::SpawnRobot::Response> response);
+
+            void pre_spawn(AzFramework::EntitySpawnTicket::Id, AzFramework::SpawnableEntityContainerView, const AZ::Transform&);
         };
 } // namespace ROS2

--- a/Code/Source/Spawner/SpawnPointComponent.cpp
+++ b/Code/Source/Spawner/SpawnPointComponent.cpp
@@ -1,0 +1,53 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#include "SpawnPointComponent.h"
+#include <AzCore/Serialization/EditContext.h>
+
+namespace ROS2 {
+    void SpawnPointComponent::Activate() {
+
+    }
+
+    void SpawnPointComponent::Deactivate() {
+    }
+
+    void SpawnPointComponent::Reflect(AZ::ReflectContext *context) {
+        if (AZ::SerializeContext *serialize = azrtti_cast<AZ::SerializeContext *>(context)) {
+            serialize->Class<SpawnPointComponent, AZ::Component>()->Version(1)
+                    ->Field("Name", &SpawnPointComponent::m_name)
+                    ->Field("Description", &SpawnPointComponent::m_description);
+
+            if (AZ::EditContext *ec = serialize->GetEditContext()) {
+                ec->Class<SpawnPointComponent>("Spawn Point", "Spawn point location")
+                        ->ClassElement(AZ::Edit::ClassElements::EditorData, "Marks a place which is good for spawning")
+                        ->Attribute(AZ::Edit::Attributes::AppearsInAddComponentMenu, AZ_CRC("Game"))
+                        ->DataElement(
+                                AZ::Edit::UIHandlers::EntityId,
+                                &SpawnPointComponent::m_name,
+                                "Name",
+                                "Name")
+                        ->DataElement(
+                                AZ::Edit::UIHandlers::EntityId,
+                                &SpawnPointComponent::m_description,
+                                "Description",
+                                "Description");
+            }
+        }
+    }
+
+    AZStd::string SpawnPointComponent::GetName() {
+        return m_name;
+    }
+
+    AZStd::string SpawnPointComponent::GetDescription() {
+        return m_description;
+    }
+}
+
+#include "SpawnPointComponent.h"

--- a/Code/Source/Spawner/SpawnPointComponent.h
+++ b/Code/Source/Spawner/SpawnPointComponent.h
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#pragma once
+
+#include <AzCore/Component/Component.h>
+#include <AzCore/Math/Vector3.h>
+
+namespace ROS2
+{
+    struct SpawnPointInfo
+    {
+        AZStd::string name;
+        AZStd::string description;
+        AZ::Vector3 position;
+    };
+
+    class SpawnPointComponent: public AZ::Component {
+    public:
+        AZ_COMPONENT(SpawnPointComponent, "{8CDC810F-9D25-4BD7-906D-6EE170CEBC55}", AZ::Component);
+
+        // AZ::Component interface implementation.
+        SpawnPointComponent() = default;
+        ~SpawnPointComponent() = default;
+
+        void Activate() override;
+        void Deactivate() override;
+
+        // Required Reflect function.
+        static void Reflect(AZ::ReflectContext* context);
+
+        AZStd::string GetName();
+        AZStd::string GetDescription();
+
+    private:
+        AZStd::string m_name = {};
+        AZStd::string m_description = {};
+    };
+}
+
+

--- a/Code/Source/Spawner/SpawnPointsBus.h
+++ b/Code/Source/Spawner/SpawnPointsBus.h
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+#pragma once
+
+#include <AzCore/EBus/EBus.h>
+#include <AzCore/Math/Vector3.h>
+#include <AzCore/RTTI/BehaviorContext.h>
+
+namespace ROS2
+{
+    //! TODO: doc
+    class SpawnPointsRequests : public AZ::EBusTraits
+    {
+        public:
+        AZ_RTTI(SpawnPointsRequests, "{3C42A3A1-1B8E-4800-9473-E4441315D7C8}");
+        virtual ~SpawnPointsRequests() = default;
+
+        //! todo: doc
+        virtual bool IsSpawnPointSuitable(const AZ::Vector3& point, const std::vector<AZ::Vector3>& bounding_box) const = 0;
+
+        // todo: doc
+        virtual std::vector<AZ::Vector3> GetSpawnPoints(const std::vector<AZ::Vector3>& bounding_box) const = 0;
+    };
+
+    class SpawnPointsBusTraits : public AZ::EBusTraits
+    {
+    public:
+        //////////////////////////////////////////////////////////////////////////
+        // EBusTraits overrides
+        static constexpr AZ::EBusHandlerPolicy HandlerPolicy = AZ::EBusHandlerPolicy::Single;
+        static constexpr AZ::EBusAddressPolicy AddressPolicy = AZ::EBusAddressPolicy::Single;
+        //////////////////////////////////////////////////////////////////////////
+    };
+
+    using SpawnPointsRequestBus = AZ::EBus<SpawnPointsRequests, SpawnPointsBusTraits>;
+    using SpawnPointsInterface = AZ::Interface<SpawnPointsRequests>;
+} // namespace ROS2

--- a/Code/Source/Spawner/SpawnPointsBus.h
+++ b/Code/Source/Spawner/SpawnPointsBus.h
@@ -10,6 +10,7 @@
 #include <AzCore/EBus/EBus.h>
 #include <AzCore/Math/Vector3.h>
 #include <AzCore/RTTI/BehaviorContext.h>
+#include <Spawner/SpawnPointComponent.h>
 
 namespace ROS2
 {
@@ -24,7 +25,7 @@ namespace ROS2
         virtual bool IsSpawnPointSuitable(const AZ::Vector3& point, const std::vector<AZ::Vector3>& bounding_box) const = 0;
 
         // todo: doc
-        virtual std::vector<AZ::Vector3> GetSpawnPoints(const std::vector<AZ::Vector3>& bounding_box) const = 0;
+        virtual std::vector<SpawnPointInfo> GetSpawnPoints(const std::vector<AZ::Vector3>& bounding_box) const = 0;
     };
 
     class SpawnPointsBusTraits : public AZ::EBusTraits

--- a/Code/ros2_files.cmake
+++ b/Code/ros2_files.cmake
@@ -70,4 +70,6 @@ set(FILES
     Source/Spawner/ROS2SpawnPointsProviderComponent.cpp
     Source/Spawner/ROS2SpawnPointsProviderComponent.h
     Source/Spawner/SpawnPointsBus.h
+    Source/Spawner/SpawnPointComponent.cpp
+    Source/Spawner/SpawnPointComponent.h
 )

--- a/Code/ros2_files.cmake
+++ b/Code/ros2_files.cmake
@@ -65,4 +65,6 @@ set(FILES
     Source/URDF/UniqueIdGenerator.h
     Source/URDF/UrdfToFbxConverter.cpp
     Source/URDF/UrdfToFbxConverter.h
+    Source/Spawner/ROS2SpawnerComponent.h
+    Source/Spawner/ROS2SpawnerComponent.cpp
 )

--- a/Code/ros2_files.cmake
+++ b/Code/ros2_files.cmake
@@ -67,4 +67,7 @@ set(FILES
     Source/URDF/UrdfToFbxConverter.h
     Source/Spawner/ROS2SpawnerComponent.h
     Source/Spawner/ROS2SpawnerComponent.cpp
+    Source/Spawner/ROS2SpawnPointsProviderComponent.cpp
+    Source/Spawner/ROS2SpawnPointsProviderComponent.h
+    Source/Spawner/SpawnPointsBus.h
 )


### PR DESCRIPTION
ROS2SpawnPointsProviderComponent created. It allows user to specify spawn points from Editor before the simulation. It also allows the user to get the list of specified points at runtime by using ros service.

To specify a spawn point user should create an entity and add ROS2SpawnPointsProviderComponent to it. Spawn points should be add as a child entities of this entity. The SpawnPointComponent should be add to all child entities.