### PR TITLE
URDF importer locale warning

### DIFF
--- a/Code/Source/RobotImporter/URDF/CollidersMaker.cpp
+++ b/Code/Source/RobotImporter/URDF/CollidersMaker.cpp
@@ -29,26 +29,6 @@ namespace ROS2
     {
         static const char* collidersMakerLoggingTag = "CollidersMaker";
 
-        void verifyTheGeometry(const urdf::Cylinder& cylinderGeometry)
-        {
-            // Due to the fact that URDF parser takes into account the locale information, incompatibility between URDF file locale and
-            // system locale might lead to incorrect URDF parsing. Mainly it affects floating point numbers, and its decimal separator. When
-            // locales are set to system with comma as decimal separator and URDF file is created with dot as decimal separator, URDF parser
-            // will trim the floating point number after comma. For example, if cylinder radius is 0.1, URDF parser will parse it as 0. At
-            // the moment of writing this code, O3DE colliders components does not deal correctly with zero radius/length, which leads to
-            // crashes. To at least point user to where the issue might be coming from, we check if the radius/length is zero, and if
-            // it is, the warning is printed
-
-            if (std::fabs(cylinderGeometry.length) < std::numeric_limits<double>::epsilon())
-            {
-                AZ_Warning(collidersMakerLoggingTag, false, "Cylinder length is 0; this might be caused by the locale settings");
-            }
-            if (std::fabs(cylinderGeometry.radius) < std::numeric_limits<double>::epsilon())
-            {
-                AZ_Warning(collidersMakerLoggingTag, false, "Cylinder radius is 0; this might be caused by the locale settings");
-            }
-        }
-
         AZ::IO::Path GetFullURDFMeshPath(AZ::IO::Path modelPath, AZ::IO::Path meshPath)
         {
             modelPath.RemoveFilename();
@@ -432,7 +412,6 @@ namespace ROS2
             {
                 auto cylinderGeometry = std::dynamic_pointer_cast<urdf::Cylinder>(geometry);
                 AZ_Assert(cylinderGeometry, "geometry is not cylinderGeometry");
-                Internal::verifyTheGeometry(*cylinderGeometry);
                 // TODO HACK Underlying API of O3DE  does not have Physic::CylinderShapeConfiguration implementation
                 Physics::BoxShapeConfiguration cfg;
                 auto* component = entity->CreateComponent<PhysX::EditorColliderComponent>(colliderConfig, cfg);

--- a/Code/Source/RobotImporter/URDF/CollidersMaker.cpp
+++ b/Code/Source/RobotImporter/URDF/CollidersMaker.cpp
@@ -24,6 +24,28 @@
 
 namespace ROS2
 {
+    namespace Internal
+    {
+        void verifyTheGeometry(const urdf::Cylinder& cylinderGeometry)
+        {
+            // Due to the fact that URDF parser takes into account the locale information, incompatibility between URDF file locale and
+            // system locale might lead to incorrect URDF parsing. Mainly it affects floating point numbers, and its decimal separator. When
+            // locales are set to system with comma as decimal separator and URDF file is created with dot as decimal separator, URDF parser
+            // will trim the floating point number after comma. For example, if cylinder radius is 0.1, URDF parser will parse it as 0. At
+            // the moment of writing this code, O3DE colliders components does not deal correctly with zero radius/length, which leads to
+            // crashes. To at least point user to where the issue might be coming from, we check if the radius/length is zero, and if
+            // it is, the warning is printed
+
+            if (std::fabs(cylinderGeometry.length) < std::numeric_limits<double>::epsilon())
+            {
+                AZ_Warning("CollisionMaker", false, "Cylinder length is 0; this might be caused by the locale settings");
+            }
+            if (std::fabs(cylinderGeometry.radius) < std::numeric_limits<double>::epsilon())
+            {
+                AZ_Warning("CollisionMaker", false, "Cylinder radius is 0; this might be caused by the locale settings");
+            }
+        }
+    } // namespace Internal
 
     CollidersMaker::CollidersMaker(AZStd::string modelPath)
         : m_modelPath(AZStd::move(modelPath))
@@ -332,6 +354,7 @@ namespace ROS2
             {
                 auto cylinderGeometry = std::dynamic_pointer_cast<urdf::Cylinder>(geometry);
                 AZ_Assert(cylinderGeometry, "geometry is not cylinderGeometry");
+                Internal::verifyTheGeometry(*cylinderGeometry);
                 // TODO HACK Underlying API of O3DE  does not have Physic::CylinderShapeConfiguration implementation
                 Physics::BoxShapeConfiguration cfg;
                 auto* component = entity->CreateComponent<PhysX::EditorColliderComponent>(colliderConfig, cfg);

--- a/Code/Source/RobotImporter/URDF/UrdfParser.cpp
+++ b/Code/Source/RobotImporter/URDF/UrdfParser.cpp
@@ -17,12 +17,29 @@
 
 namespace ROS2
 {
+    namespace Internal
+    {
+        void checkIfCurrentLocaleHasDotAsADecimalSeparator()
+        {
+            // Due to the fact that URDF parser takes into account the locale information, incompatibility between URDF file locale and
+            // system locale might lead to incorrect URDF parsing. Mainly it affects floating point numbers, and its decimal separator. When
+            // locales are set to system with comma as decimal separator and URDF file is created with dot as decimal separator, URDF parser
+            // will trim the floating point number after comma. For example, if parsing 0.1, URDF parser will parse it as 0.
+            // This might lead to incorrect URDF loading. Most widely used separator is a dot. If in current locale it is not the case a
+            // warning is presented to the user that his system's locale seem unusual, and he should double-check it
+
+            std::locale currentLocale("");
+            if (std::use_facet<std::numpunct<char>>(currentLocale).decimal_point() != '.')
+            {
+                AZ_Warning(
+                    "UrdfParser", false, "Locale %s might be incompatible with the URDF file content.\n", currentLocale.name().c_str());
+            }
+        }
+    } // namespace Internal
+
     urdf::ModelInterfaceSharedPtr UrdfParser::Parse(const AZStd::string& xmlString)
     {
-        if (std::string currentLocale = std::setlocale(LC_NUMERIC, ""); currentLocale != "en_US.UTF-8")
-        {
-            AZ_Warning("UrdfParser", false, "Locale %s might be incompatible with the URDF file content.");
-        }
+        Internal::checkIfCurrentLocaleHasDotAsADecimalSeparator();
         return urdf::parseURDF(xmlString.c_str());
     }
 

--- a/Code/Source/RobotImporter/URDF/UrdfParser.cpp
+++ b/Code/Source/RobotImporter/URDF/UrdfParser.cpp
@@ -19,6 +19,7 @@ namespace ROS2
 {
     urdf::ModelInterfaceSharedPtr UrdfParser::Parse(const AZStd::string& xmlString)
     {
+        std::setlocale(LC_NUMERIC, "en_US.UTF-8");
         return urdf::parseURDF(xmlString.c_str());
     }
 

--- a/Code/Source/RobotImporter/URDF/UrdfParser.cpp
+++ b/Code/Source/RobotImporter/URDF/UrdfParser.cpp
@@ -19,6 +19,10 @@ namespace ROS2
 {
     urdf::ModelInterfaceSharedPtr UrdfParser::Parse(const AZStd::string& xmlString)
     {
+        if (std::string currentLocale = std::setlocale(LC_NUMERIC, ""); currentLocale != "en_US.UTF-8")
+        {
+            AZ_Warning("UrdfParser", false, "Locale %s might be incompatible with the URDF file content.");
+        }
         return urdf::parseURDF(xmlString.c_str());
     }
 

--- a/Code/Source/RobotImporter/URDF/UrdfParser.cpp
+++ b/Code/Source/RobotImporter/URDF/UrdfParser.cpp
@@ -19,8 +19,11 @@ namespace ROS2
 {
     urdf::ModelInterfaceSharedPtr UrdfParser::Parse(const AZStd::string& xmlString)
     {
+        auto currentLocale = std::setlocale(LC_NUMERIC, nullptr);
         std::setlocale(LC_NUMERIC, "en_US.UTF-8");
-        return urdf::parseURDF(xmlString.c_str());
+        urdf::ModelInterfaceSharedPtr urdfModel = urdf::parseURDF(xmlString.c_str());
+        std::setlocale(LC_NUMERIC, currentLocale);
+        return urdfModel;
     }
 
     urdf::ModelInterfaceSharedPtr UrdfParser::ParseFromFile(const AZStd::string& filePath)

--- a/Code/Source/RobotImporter/URDF/UrdfParser.cpp
+++ b/Code/Source/RobotImporter/URDF/UrdfParser.cpp
@@ -19,11 +19,7 @@ namespace ROS2
 {
     urdf::ModelInterfaceSharedPtr UrdfParser::Parse(const AZStd::string& xmlString)
     {
-        auto currentLocale = std::setlocale(LC_NUMERIC, nullptr);
-        std::setlocale(LC_NUMERIC, "en_US.UTF-8");
-        urdf::ModelInterfaceSharedPtr urdfModel = urdf::parseURDF(xmlString.c_str());
-        std::setlocale(LC_NUMERIC, currentLocale);
-        return urdfModel;
+        return urdf::parseURDF(xmlString.c_str());
     }
 
     urdf::ModelInterfaceSharedPtr UrdfParser::ParseFromFile(const AZStd::string& filePath)


### PR DESCRIPTION
Since URDF parser uses locale information, it might incorrectly read files if the decimal delimiter is not compatible. This PR fixes this by forcing numeric locale to be `en_US.UTF-8` which is the most commonly used in the URDF files.