### PR TITLE
Set larger number of iterations with imported URDFs

### DIFF
--- a/Code/Source/RobotImporter/URDF/InertialsMaker.cpp
+++ b/Code/Source/RobotImporter/URDF/InertialsMaker.cpp
@@ -14,6 +14,9 @@
 
 namespace ROS2
 {
+    constexpr AZ::u8 kMinimalNumPosSolv = 40;
+    constexpr AZ::u8 kMinimalNumVelSolv = 10;
+
     void InertialsMaker::AddInertial(urdf::InertialSharedPtr inertial, AZ::EntityId entityId)
     {
         if (!inertial)
@@ -24,6 +27,10 @@ namespace ROS2
 
         AZ::Entity* entity = AzToolsFramework::GetEntityById(entityId);
         PhysX::EditorRigidBodyConfiguration rigidBodyConfiguration;
+        PhysX::RigidBodyConfiguration physxSpecificConfiguration;
+        physxSpecificConfiguration.m_solverPositionIterations = kMinimalNumPosSolv;
+        physxSpecificConfiguration.m_solverVelocityIterations = kMinimalNumVelSolv;
+
         rigidBodyConfiguration.m_mass = inertial->mass;
         rigidBodyConfiguration.m_computeMass = false;
 
@@ -45,6 +52,6 @@ namespace ROS2
         rigidBodyConfiguration.m_inertiaTensor = inertiaMatrix;
         rigidBodyConfiguration.m_computeInertiaTensor = false;
 
-        entity->CreateComponent<PhysX::EditorRigidBodyComponent>(rigidBodyConfiguration);
+        entity->CreateComponent<PhysX::EditorRigidBodyComponent>(rigidBodyConfiguration, physxSpecificConfiguration);
     }
 } // namespace ROS2

--- a/Code/Source/RobotImporter/URDF/InertialsMaker.cpp
+++ b/Code/Source/RobotImporter/URDF/InertialsMaker.cpp
@@ -14,6 +14,8 @@
 
 namespace ROS2
 {
+    // Here is the recommended, minimal number of iterations for position and velocity solver.
+    // It is needed since currently o3de default values are optimized for the gaming experience, not a simulation.
     constexpr AZ::u8 kMinimalNumPosSolv = 40;
     constexpr AZ::u8 kMinimalNumVelSolv = 10;
 
@@ -28,8 +30,10 @@ namespace ROS2
         AZ::Entity* entity = AzToolsFramework::GetEntityById(entityId);
         PhysX::EditorRigidBodyConfiguration rigidBodyConfiguration;
         PhysX::RigidBodyConfiguration physxSpecificConfiguration;
-        physxSpecificConfiguration.m_solverPositionIterations = kMinimalNumPosSolv;
-        physxSpecificConfiguration.m_solverVelocityIterations = kMinimalNumVelSolv;
+        physxSpecificConfiguration.m_solverPositionIterations =
+            AZStd::max(physxSpecificConfiguration.m_solverPositionIterations, kMinimalNumPosSolv);
+        physxSpecificConfiguration.m_solverVelocityIterations =
+            AZStd::max(physxSpecificConfiguration.m_solverVelocityIterations, kMinimalNumVelSolv);
 
         rigidBodyConfiguration.m_mass = inertial->mass;
         rigidBodyConfiguration.m_computeMass = false;


### PR DESCRIPTION
The number of iterations vof solvers are set to larger number 40 for position and 10 for velocity

Signed-off-by: Michał Pełka <michalpelka@gmail.com>