### PR TITLE
Wheel dynamics improvements:

### DIFF
--- a/Code/Source/VehicleDynamics/AxleConfiguration.cpp
+++ b/Code/Source/VehicleDynamics/AxleConfiguration.cpp
@@ -17,9 +17,10 @@ namespace VehicleDynamics
         if (AZ::SerializeContext* serialize = azrtti_cast<AZ::SerializeContext*>(context))
         {
             serialize->Class<AxleConfiguration>()
-                ->Version(1)
+                ->Version(2)
                 ->Field("AxleTag", &AxleConfiguration::m_axleTag)
                 ->Field("AxleWheels", &AxleConfiguration::m_axleWheels)
+                ->Field("WheelRadius", &AxleConfiguration::m_wheelRadius)
                 ->Field("IsSteering", &AxleConfiguration::m_isSteering)
                 ->Field("IsDrive", &AxleConfiguration::m_isDrive);
 
@@ -40,6 +41,11 @@ namespace VehicleDynamics
                         &AxleConfiguration::m_isDrive,
                         "Is it a drive axle",
                         "Is this axle used for drive (all attached wheels)")
+                    ->DataElement(
+                        AZ::Edit::UIHandlers::Default,
+                        &AxleConfiguration::m_wheelRadius,
+                        "Wheel radius",
+                        "Radius of each wheel attached to axle")
                     ->DataElement(
                         AZ::Edit::UIHandlers::Default,
                         &AxleConfiguration::m_axleWheels,

--- a/Code/Source/VehicleDynamics/AxleConfiguration.h
+++ b/Code/Source/VehicleDynamics/AxleConfiguration.h
@@ -30,6 +30,7 @@ namespace VehicleDynamics
         AZStd::string m_axleTag; //! Useful to differentiate between axles, can be empty.
         AZStd::vector<AZ::EntityId> m_axleWheels; //! One or more wheels attached to this axle (typically 2), sorted left to right.
 
+        float m_wheelRadius = 0.35f; // TODO - this could be deduced from a model for a better default
         bool m_isSteering = false;
         bool m_isDrive = false;
     };

--- a/Code/Source/VehicleDynamics/DriveModel.h
+++ b/Code/Source/VehicleDynamics/DriveModel.h
@@ -26,8 +26,7 @@ namespace VehicleDynamics
         static void Reflect(AZ::ReflectContext* context);
         virtual ~DriveModel() = default;
         virtual DriveModel::DriveModelType DriveType() = 0;
-        virtual void Activate() = 0;
-        virtual void ApplyInputState(
-            const VehicleInputsState& inputs, const ChassisConfiguration& vehicleChassis, uint64_t deltaTimeNs) = 0;
+        virtual void Activate(const ChassisConfiguration& vehicleChassis) = 0;
+        virtual void ApplyInputState(const VehicleInputsState& inputs, uint64_t deltaTimeNs) = 0;
     };
 } // namespace VehicleDynamics

--- a/Code/Source/VehicleDynamics/DriveModels/SimplifiedDriveModel.h
+++ b/Code/Source/VehicleDynamics/DriveModels/SimplifiedDriveModel.h
@@ -11,6 +11,7 @@
 #include "VehicleDynamics/DriveModel.h"
 #include "VehicleDynamics/DriveModels/PidConfiguration.h"
 #include "VehicleDynamics/VehicleInputsState.h"
+#include "VehicleDynamics/WheelDynamicsData.h"
 #include <AzCore/Serialization/SerializeContext.h>
 
 namespace VehicleDynamics
@@ -24,15 +25,17 @@ namespace VehicleDynamics
         {
             return DriveModel::SimplifiedDriveModelType;
         }
-        void Activate() override;
-        void ApplyInputState(const VehicleInputsState& inputs, const ChassisConfiguration& vehicleChassis, uint64_t deltaTimeNs) override;
+        void Activate(const ChassisConfiguration& vehicleChassis) override;
+        void ApplyInputState(const VehicleInputsState& inputs, uint64_t deltaTimeNs) override;
 
         static void Reflect(AZ::ReflectContext* context);
 
     private:
-        void ApplySteering(float steering, const ChassisConfiguration& vehicleChassis, uint64_t deltaTimeNs);
-        void ApplySpeed(float speed, const ChassisConfiguration& vehicleChassis, uint64_t deltaTimeNs);
+        void ApplySteering(float steering, uint64_t deltaTimeNs);
+        void ApplySpeed(float speed, uint64_t deltaTimeNs);
 
+        AZStd::vector<WheelDynamicsData> m_driveWheelsData;
+        AZStd::vector<SteeringDynamicsData> m_steeringData;
         PidConfiguration m_steeringPid;
         PidConfiguration m_speedPid;
     };

--- a/Code/Source/VehicleDynamics/Utilities.h
+++ b/Code/Source/VehicleDynamics/Utilities.h
@@ -9,17 +9,17 @@
 
 #include "AxleConfiguration.h"
 #include "ChassisConfiguration.h"
+#include "WheelDynamicsData.h"
 #include <AzCore/Component/EntityId.h>
 #include <AzCore/std/containers/vector.h>
 #include <AzCore/std/string/string.h>
 
 namespace VehicleDynamics::Utilities
 {
-    AxleConfiguration Create2WheelAxle(AZ::EntityId leftWheel, AZ::EntityId rightWheel, AZStd::string tag, bool steering, bool drive);
-    AxleConfiguration CreateFrontSteerAndDriveAxle(AZ::EntityId leftWheel, AZ::EntityId rightWheel);
-    AxleConfiguration CreateRearDriveAxle(AZ::EntityId leftWheel, AZ::EntityId rightWheel);
-
-    // TODO - run and cache on Activate
-    AZStd::vector<AZStd::pair<AZ::EntityId, AZ::Vector3>> GetAllSteeringEntitiesAndAxes(const ChassisConfiguration& chassisConfig);
-    AZStd::vector<AZStd::pair<AZ::EntityId, AZ::Vector3>> GetAllDriveWheelEntitiesAndAxes(const ChassisConfiguration& chassisConfig);
+    AxleConfiguration Create2WheelAxle(
+        AZ::EntityId leftWheel, AZ::EntityId rightWheel, AZStd::string tag, float wheelRadius, bool steering, bool drive);
+    AxleConfiguration CreateFrontSteerAndDriveAxle(AZ::EntityId leftWheel, AZ::EntityId rightWheel, float wheelRadius);
+    AxleConfiguration CreateRearDriveAxle(AZ::EntityId leftWheel, AZ::EntityId rightWheel, float wheelRadius);
+    AZStd::vector<VehicleDynamics::SteeringDynamicsData> GetAllSteeringEntitiesData(const ChassisConfiguration& chassisConfig);
+    AZStd::vector<VehicleDynamics::WheelDynamicsData> GetAllDriveWheelsData(const ChassisConfiguration& chassisConfig);
 } // namespace VehicleDynamics::Utilities

--- a/Code/Source/VehicleDynamics/VehicleModelComponent.cpp
+++ b/Code/Source/VehicleDynamics/VehicleModelComponent.cpp
@@ -23,7 +23,7 @@ namespace VehicleDynamics
         VehicleInputControlRequestBus::Handler::BusConnect();
         m_manualControlEventHandler.Activate();
         AZ::TickBus::Handler::BusConnect();
-        m_driveModel.Activate();
+        m_driveModel.Activate(m_chassisConfiguration);
     }
 
     void VehicleModelComponent::Deactivate()
@@ -101,6 +101,6 @@ namespace VehicleDynamics
     void VehicleModelComponent::OnTick(float deltaTime, [[maybe_unused]] AZ::ScriptTimePoint time)
     {
         uint64_t deltaTimeNs = deltaTime * 1000000000;
-        m_driveModel.ApplyInputState(m_inputsState, m_chassisConfiguration, deltaTimeNs);
+        m_driveModel.ApplyInputState(m_inputsState, deltaTimeNs);
     }
 } // namespace VehicleDynamics

--- a/Code/Source/VehicleDynamics/VehicleModelComponent.h
+++ b/Code/Source/VehicleDynamics/VehicleModelComponent.h
@@ -50,9 +50,6 @@ namespace VehicleDynamics
         VehicleInputsState m_inputsState;
         SimplifiedDriveModel m_driveModel; // TODO - use abstraction here (DriveModel)
         VehicleModelLimits m_vehicleLimits;
-
-        float m_accumulatedTimeoutSpeed = 0; // TODO - separate out into inputs timeout handler
-        float m_accumulatedTimeoutSteering = 0;
         // TODO - Engine, Transmission, Lights, etc.
     };
 } // namespace VehicleDynamics

--- a/Code/Source/VehicleDynamics/WheelControllerComponent.cpp
+++ b/Code/Source/VehicleDynamics/WheelControllerComponent.cpp
@@ -46,8 +46,8 @@ namespace VehicleDynamics
                 ->Version(1)
                 ->Field("SteeringEntity", &WheelControllerComponent::m_steeringEntity)
                 ->Field("VisualEntity", &WheelControllerComponent::m_visualEntity)
-                ->Field("DriveDir", &WheelControllerComponent::m_drive_dir)
-                ->Field("SteeringDir", &WheelControllerComponent::m_steering_dir);
+                ->Field("DriveDir", &WheelControllerComponent::m_driveDir)
+                ->Field("SteeringDir", &WheelControllerComponent::m_steeringDir);
 
             if (AZ::EditContext* ec = serialize->GetEditContext())
             {
@@ -66,12 +66,12 @@ namespace VehicleDynamics
                         "Entity which holds wheel visual (mesh) - typically a child entity")
                     ->DataElement(
                         AZ::Edit::UIHandlers::Default,
-                        &WheelControllerComponent::m_drive_dir,
+                        &WheelControllerComponent::m_driveDir,
                         "Direction of drive axis",
                         "The direction of torque applied to the wheel entity")
                     ->DataElement(
                         AZ::Edit::UIHandlers::Default,
-                        &WheelControllerComponent::m_steering_dir,
+                        &WheelControllerComponent::m_steeringDir,
                         "Direction of steering axis",
                         "The direction of torque applied to the steering entity");
             }

--- a/Code/Source/VehicleDynamics/WheelControllerComponent.h
+++ b/Code/Source/VehicleDynamics/WheelControllerComponent.h
@@ -31,7 +31,7 @@ namespace VehicleDynamics
 
         AZ::EntityId m_steeringEntity; //! Rigid body to apply torque to. TODO - parent, this entity or custom.
         AZ::EntityId m_visualEntity; //! Primary visual mesh or primitive for the wheel. It will be rotated according to the motion.
-        AZ::Vector3 m_drive_dir{ 0.0, 0.0, 1.0 }; //! The direction of torque applied to wheel entity when speed is applied
-        AZ::Vector3 m_steering_dir{ 0.0, 0.0, 1.0 }; //! The direction of torque applied to steering entity when steering is applied
+        AZ::Vector3 m_driveDir{ 0.0, 0.0, 1.0 }; //! The direction of torque applied to wheel entity when speed is applied
+        AZ::Vector3 m_steeringDir{ 0.0, 0.0, 1.0 }; //! The direction of torque applied to steering entity when steering is applied
     };
 } // namespace VehicleDynamics

--- a/Code/Source/VehicleDynamics/WheelDynamicsData.h
+++ b/Code/Source/VehicleDynamics/WheelDynamicsData.h
@@ -12,7 +12,6 @@ namespace VehicleDynamics
     //! Data structure to pass wheel dynamics data for a single wheel
     struct WheelDynamicsData
     {
-    public:
         AZ::EntityId m_wheelEntity;
         AZ::Vector3 m_driveAxis;
         float m_wheelRadius;

--- a/Code/Source/VehicleDynamics/WheelDynamicsData.h
+++ b/Code/Source/VehicleDynamics/WheelDynamicsData.h
@@ -1,0 +1,26 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+#pragma once
+
+namespace VehicleDynamics
+{
+    //! Data structure to pass wheel dynamics data for a single wheel
+    struct WheelDynamicsData
+    {
+    public:
+        AZ::EntityId m_wheelEntity;
+        AZ::Vector3 m_driveAxis;
+        float m_wheelRadius;
+    };
+
+    struct SteeringDynamicsData
+    {
+        AZ::EntityId m_steeringEntity;
+        AZ::Vector3 m_turnAxis;
+    };
+} // namespace VehicleDynamics

--- a/Code/ros2_files.cmake
+++ b/Code/ros2_files.cmake
@@ -97,4 +97,5 @@ set(FILES
         Source/VehicleDynamics/VehicleModelLimits.h
         Source/VehicleDynamics/WheelControllerComponent.cpp
         Source/VehicleDynamics/WheelControllerComponent.h
+        Source/VehicleDynamics/WheelDynamicsData.h
         )


### PR DESCRIPTION
- removed turning input negative (instead, set axis and input properly)
- wheel radius is now configurable (per axle), defaults to 0.35 meters
- drive wheels and steering elements are now computed on activation, instead of each frame
- some names have been changed to match the naming convention

Signed-off-by: Adam Dabrowski <adam.dabrowski@robotec.ai>