### PR TITLE
Changed Components to EditorComponent where applicable.

### DIFF
--- a/Code/Source/Frame/ROS2FrameComponent.h
+++ b/Code/Source/Frame/ROS2FrameComponent.h
@@ -9,9 +9,9 @@
 
 #include "Frame/NamespaceConfiguration.h"
 #include "Frame/ROS2Transform.h"
-#include <AzCore/Component/Component.h>
 #include <AzCore/std/smart_ptr/unique_ptr.h>
 #include <AzFramework/Components/TransformComponent.h>
+#include <AzToolsFramework/ToolsComponents/EditorComponentBase.h>
 
 namespace ROS2
 {
@@ -21,11 +21,11 @@ namespace ROS2
     //! An entity can only have a single ROS2Frame on each level. Many ROS2 Components require this component.
     //! @note A robot should have this component on every level of entity hierarchy (for each joint, fixed or dynamic)
     class ROS2FrameComponent
-        : public AZ::Component
+        : public AzToolsFramework::Components::EditorComponentBase
         , public AZ::TickBus::Handler
     {
     public:
-        AZ_COMPONENT(ROS2FrameComponent, "{EE743472-3E25-41EA-961B-14096AC1D66F}");
+        AZ_EDITOR_COMPONENT(ROS2FrameComponent, "{EE743472-3E25-41EA-961B-14096AC1D66F}");
 
         ROS2FrameComponent();
         ROS2FrameComponent(AZStd::string frameId);

--- a/Code/Source/RobotControl/ROS2RobotControlComponent.h
+++ b/Code/Source/RobotControl/ROS2RobotControlComponent.h
@@ -9,18 +9,18 @@
 
 #include "ControlConfiguration.h"
 #include "RobotControl/RobotControl.h"
-#include <AzCore/Component/Component.h>
 #include <AzCore/std/smart_ptr/unique_ptr.h>
+#include <AzToolsFramework/ToolsComponents/EditorComponentBase.h>
 
 namespace ROS2
 {
     //! A Component responsible for controlling a robot movement.
     //! Uses IRobotControl implementation depending on type of ROS2 control message.
     //! Depends on ROS2FrameComponent. Can be configured through ControlConfiguration.
-    class ROS2RobotControlComponent : public AZ::Component
+    class ROS2RobotControlComponent : public AzToolsFramework::Components::EditorComponentBase
     {
     public:
-        AZ_COMPONENT(ROS2RobotControlComponent, "{CBFB0764-99F9-40EE-9FEE-F5F5A66E59D2}", AZ::Component);
+        AZ_EDITOR_COMPONENT(ROS2RobotControlComponent, "{CBFB0764-99F9-40EE-9FEE-F5F5A66E59D2}");
         ROS2RobotControlComponent() = default;
         ROS2RobotControlComponent(ControlConfiguration controlConfiguration)
             : m_controlConfiguration(AZStd::move(controlConfiguration))

--- a/Code/Source/RobotImporter/ROS2RobotImporterSystemComponent.h
+++ b/Code/Source/RobotImporter/ROS2RobotImporterSystemComponent.h
@@ -8,16 +8,16 @@
 
 #pragma once
 
-#include <AzCore/Component/Component.h>
+#include <AzToolsFramework/ToolsComponents/EditorComponentBase.h>
 
 namespace ROS2
 {
     //! A Component for importing robot definition from standard formats such as URDF.
     //! Sometimes, user decisions will be involved in the process.
-    class ROS2RobotImporterSystemComponent : public AZ::Component
+    class ROS2RobotImporterSystemComponent : public AzToolsFramework::Components::EditorComponentBase
     {
     public:
-        AZ_COMPONENT(ROS2RobotImporterSystemComponent, "{f2566021-450a-4eae-896f-b268492a58eb}");
+        AZ_EDITOR_COMPONENT(ROS2RobotImporterSystemComponent, "{f2566021-450a-4eae-896f-b268492a58eb}");
         static void Reflect(AZ::ReflectContext* context);
 
         static void GetProvidedServices(AZ::ComponentDescriptor::DependencyArrayType& provided);

--- a/Code/Source/Sensor/ROS2SensorComponent.h
+++ b/Code/Source/Sensor/ROS2SensorComponent.h
@@ -8,9 +8,9 @@
 #pragma once
 
 #include "SensorConfiguration.h"
-#include <AzCore/Component/Component.h>
 #include <AzCore/Component/TickBus.h>
 #include <AzCore/std/smart_ptr/unique_ptr.h>
+#include <AzToolsFramework/ToolsComponents/EditorComponentBase.h>
 
 namespace ROS2
 {
@@ -18,13 +18,13 @@ namespace ROS2
     //! Sensors acquire data from the simulation engine and publish it to ROS2 ecosystem.
     //! Derive this Component to implement a new ROS2 sensor. Each sensor Component requires ROS2FrameComponent.
     class ROS2SensorComponent
-        : public AZ::Component
+        : public AzToolsFramework::Components::EditorComponentBase
         , public AZ::TickBus::Handler // TODO - high resolution tick source?
     {
     public:
         ROS2SensorComponent() = default;
         virtual ~ROS2SensorComponent() = default;
-        AZ_COMPONENT(ROS2SensorComponent, "{91BCC1E9-6D93-4466-9CDB-E73D497C6B5E}");
+        AZ_EDITOR_COMPONENT(ROS2SensorComponent, "{91BCC1E9-6D93-4466-9CDB-E73D497C6B5E}");
 
         void Activate() override;
         void Deactivate() override;


### PR DESCRIPTION
This change allows handling of o3de Editor correctly components. 
It fixes the problem described in #217 - Editor crash when building context menu for the component.
Signed-off-by: Michał Pełka <michalpelka@gmail.com>