### PR TITLE
Removed auto-created colliders in URDF importer

### DIFF
--- a/Code/Source/RobotImporter/URDF/JointsMaker.cpp
+++ b/Code/Source/RobotImporter/URDF/JointsMaker.cpp
@@ -25,45 +25,8 @@ namespace ROS2
             if (joint->child_link_name == childLink->name)
             { // Found a match!
                 PrefabMakerUtils::SetEntityTransform(joint->parent_to_joint_origin_transform, linkChildId);
-                return AddJoint(joint, linkChildId, linkParentId);
+                return AddJointComponent(joint, linkChildId, linkParentId);
             }
-        }
-    }
-
-    void JointsMaker::AddJoint(urdf::JointSharedPtr joint, AZ::EntityId linkChildId, AZ::EntityId linkParentId)
-    {
-        // In URDF, we can have joints between links that have no colliders (for fixed joints).
-        // In O3DE physics, colliders are necessary for joints, in both lead and follower entities.
-        // We will add unconfigured (asset-less) collider components to support this case.
-        for (auto entityId : { linkParentId, linkChildId })
-        {
-            if (!PrefabMakerUtils::HasCollider(entityId))
-            {
-                AddColliderForFixedJoint(joint, entityId);
-            }
-        }
-
-        if (!PrefabMakerUtils::HasCollider(linkChildId) || !PrefabMakerUtils::HasCollider(linkParentId))
-        { // This check should always pass unless adding colliders earlier failed for some reason or URDF is ill-defined
-            AZ_Error("AddJoint", false, "Unable to add a joint %s without lead and follow colliders", joint->name.c_str());
-            return;
-        }
-        AddJointComponent(joint, linkChildId, linkParentId);
-    }
-
-    void JointsMaker::AddColliderForFixedJoint(urdf::JointSharedPtr joint, AZ::EntityId entityId)
-    { // Both Collider and RigidBody are required, provide kinematic, not simulated
-        AZ::Entity* entity = AzToolsFramework::GetEntityById(entityId);
-
-        Physics::ColliderConfiguration colliderConfig;
-        colliderConfig.m_isSimulated = false;
-        AZ::Vector3 smallBoxDim(0.001f, 0.001f, 0.001f);
-        Physics::BoxShapeConfiguration box(smallBoxDim);
-        entity->CreateComponent<PhysX::EditorColliderComponent>(colliderConfig, box);
-        if (!entity->FindComponent<PhysX::EditorRigidBodyComponent>())
-        {
-            AZ_TracePrintf("AddColliderForFixedJoint", "Adding RigidBody for entity id:%s", entityId.ToString().c_str());
-            entity->CreateComponent<PhysX::EditorRigidBodyComponent>();
         }
     }
 

--- a/Code/Source/RobotImporter/URDF/JointsMaker.h
+++ b/Code/Source/RobotImporter/URDF/JointsMaker.h
@@ -27,8 +27,6 @@ namespace ROS2
         void AddJoint(urdf::LinkSharedPtr parentLink, urdf::LinkSharedPtr childLink, AZ::EntityId linkChildId, AZ::EntityId linkParentId);
 
     private:
-        void AddJoint(urdf::JointSharedPtr joint, AZ::EntityId linkChildId, AZ::EntityId linkParentId);
-        void AddColliderForFixedJoint(urdf::JointSharedPtr joint, AZ::EntityId entityId);
         void AddJointComponent(urdf::JointSharedPtr joint, AZ::EntityId followColliderEntityId, AZ::EntityId leadColliderEntityId);
     };
 } // namespace ROS2


### PR DESCRIPTION
Since o3de lifted the requirement that an entity needs to have a collider in order to have a joint, there is no need to create dummy colliders.

Signed-off-by: Michał Pełka <michalpelka@gmail.com>