### PR TITLE
Default spawn point

### DIFF
--- a/Code/Source/ROS2EditorModule.cpp
+++ b/Code/Source/ROS2EditorModule.cpp
@@ -21,7 +21,7 @@ namespace ROS2
         {
             // Push results of [MyComponent]::CreateDescriptor() into m_descriptors here.
             // Add ALL components descriptors associated with this gem to m_descriptors.
-            // This will associate the AzTypeInfo information for the components with the the SerializeContext, BehaviorContext and
+            // This will associate the AzTypeInfo information for the components with the SerializeContext, BehaviorContext and
             // EditContext. This happens through the [MyComponent]::Reflect() function.
             m_descriptors.insert(
                 m_descriptors.end(),

--- a/Code/Source/ROS2ModuleInterface.h
+++ b/Code/Source/ROS2ModuleInterface.h
@@ -12,7 +12,6 @@
 #include "GNSS/ROS2GNSSSensorComponent.h"
 #include "Imu/ROS2ImuSensorComponent.h"
 #include "Lidar/ROS2LidarSensorComponent.h"
-#include "Spawner/ROS2SpawnerComponent.h"
 #include "ROS2SystemComponent.h"
 #include "RobotControl/ROS2RobotControlComponent.h"
 #include "RobotImporter/ROS2RobotImporterSystemComponent.h"

--- a/Code/Source/ROS2ModuleInterface.h
+++ b/Code/Source/ROS2ModuleInterface.h
@@ -12,6 +12,7 @@
 #include "GNSS/ROS2GNSSSensorComponent.h"
 #include "Imu/ROS2ImuSensorComponent.h"
 #include "Lidar/ROS2LidarSensorComponent.h"
+#include "Spawner/ROS2SpawnerComponent.h"
 #include "ROS2SystemComponent.h"
 #include "RobotControl/ROS2RobotControlComponent.h"
 #include "RobotImporter/ROS2RobotImporterSystemComponent.h"

--- a/Code/Source/RobotImporter/URDF/URDFPrefabMaker.cpp
+++ b/Code/Source/RobotImporter/URDF/URDFPrefabMaker.cpp
@@ -16,6 +16,9 @@
 #include <AzToolsFramework/Entity/EditorEntityHelpers.h>
 #include <AzToolsFramework/Prefab/PrefabLoaderInterface.h>
 #include <AzToolsFramework/Prefab/PrefabSystemComponentInterface.h>
+#include <AzToolsFramework/ToolsComponents/TransformComponent.h>
+
+#include <Spawner/SpawnerBus.h>
 
 namespace ROS2
 {
@@ -128,6 +131,8 @@ namespace ROS2
             m_jointsMaker.AddJoint(link, childLink, childEntityId, entityId);
         }
 
+        MoveEntityToDefaultSpawnPoint(entityId);
+
         return AZ::Success(entityId);
     }
 
@@ -145,5 +150,29 @@ namespace ROS2
     const AZStd::string& URDFPrefabMaker::GetPrefabPath() const
     {
         return m_prefabPath;
+    }
+
+    void URDFPrefabMaker::MoveEntityToDefaultSpawnPoint(const AZ::EntityId& rootEntityId)
+    {
+        auto spawner = ROS2::SpawnerInterface::Get();
+
+        if (spawner == nullptr)
+        {
+            AZ_TracePrintf("URDF Importer", "Spawner not found - creating entity in (0,0,0)") return;
+        }
+
+        auto entity_ = AzToolsFramework::GetEntityById(rootEntityId);
+        auto* transformInterface_ = entity_->FindComponent<AzToolsFramework::Components::TransformComponent>();
+
+        if (transformInterface_ == nullptr)
+        {
+            AZ_TracePrintf("URDF Importer", "TransformComponent not found in created entity") return;
+        }
+
+        AZ::Vector3 pos = spawner->GetDefaultSpawnPoint();
+
+        auto transform = AZ::Transform(pos, AZ::Quaternion(0.0f, 0.0f, 0.0f, 1.0f), 1.0f);
+
+        transformInterface_->SetWorldTM(transform);
     }
 } // namespace ROS2

--- a/Code/Source/RobotImporter/URDF/URDFPrefabMaker.cpp
+++ b/Code/Source/RobotImporter/URDF/URDFPrefabMaker.cpp
@@ -169,10 +169,8 @@ namespace ROS2
             AZ_TracePrintf("URDF Importer", "TransformComponent not found in created entity") return;
         }
 
-        AZ::Vector3 pos = spawner->GetDefaultSpawnPoint();
+        auto pose = spawner->GetDefaultSpawnPose();
 
-        auto transform = AZ::Transform(pos, AZ::Quaternion(0.0f, 0.0f, 0.0f, 1.0f), 1.0f);
-
-        transformInterface_->SetWorldTM(transform);
+        transformInterface_->SetWorldTM(pose);
     }
 } // namespace ROS2

--- a/Code/Source/RobotImporter/URDF/URDFPrefabMaker.h
+++ b/Code/Source/RobotImporter/URDF/URDFPrefabMaker.h
@@ -36,6 +36,7 @@ namespace ROS2
         AzToolsFramework::Prefab::PrefabEntityResult AddEntitiesForLink(urdf::LinkSharedPtr link, AZ::EntityId parentEntityId);
         void BuildAssetsForLink(urdf::LinkSharedPtr link);
         void AddRobotControl(AZ::EntityId rootEntityId);
+        static void MoveEntityToDefaultSpawnPoint(const AZ::EntityId& rootEntityId);
 
         urdf::ModelInterfaceSharedPtr m_model;
         AZStd::string m_prefabPath;

--- a/Code/Source/Spawner/ROS2SpawnerComponent.cpp
+++ b/Code/Source/Spawner/ROS2SpawnerComponent.cpp
@@ -57,7 +57,7 @@ namespace ROS2
             serialize->Class<ROS2SpawnerComponent, AZ::Component>()
                 ->Version(1)
                 ->Field("Spawnables", &ROS2SpawnerComponent::m_spawnables)
-                ->Field("Default spawn point", &ROS2SpawnerComponent::m_defaultSpawnPoint);
+                ->Field("Default spawn point", &ROS2SpawnerComponent::m_defaultSpawnPose);
 
             if (AZ::EditContext* ec = serialize->GetEditContext())
             {
@@ -67,9 +67,9 @@ namespace ROS2
                     ->DataElement(AZ::Edit::UIHandlers::EntityId, &ROS2SpawnerComponent::m_spawnables, "Spawnables", "Spawnables")
                     ->DataElement(
                         AZ::Edit::UIHandlers::EntityId,
-                        &ROS2SpawnerComponent::m_defaultSpawnPoint,
-                        "Default spawn point",
-                        "Default spawn point");
+                        &ROS2SpawnerComponent::m_defaultSpawnPose,
+                        "Default spawn pose",
+                        "Default spawn pose");
             }
         }
     }
@@ -87,9 +87,7 @@ namespace ROS2
     {
         AZStd::string_view key(request->name.c_str(), request->name.size());
 
-        auto spawnable = m_spawnables.find(key);
-
-        if (spawnable == m_spawnables.end())
+        if (!m_spawnables.contains(key))
         {
             response->success = false;
             response->status_message = "Requested spawnable name not found";
@@ -100,6 +98,7 @@ namespace ROS2
         {
             // if a ticket for this spawnable was not created but the spawnable name is correct, create the ticket and then use it to
             // spawn an entity
+            auto spawnable = m_spawnables.find(key);
             m_tickets.emplace(spawnable->first, AzFramework::EntitySpawnTicket(spawnable->second));
         }
 
@@ -141,8 +140,8 @@ namespace ROS2
         transformInterface_->SetWorldTM(transform);
     }
 
-    const AZ::Vector3& ROS2SpawnerComponent::GetDefaultSpawnPoint() const
+    const AZ::Transform& ROS2SpawnerComponent::GetDefaultSpawnPose() const
     {
-        return m_defaultSpawnPoint;
+        return m_defaultSpawnPose;
     }
 } // namespace ROS2

--- a/Code/Source/Spawner/ROS2SpawnerComponent.cpp
+++ b/Code/Source/Spawner/ROS2SpawnerComponent.cpp
@@ -122,5 +122,4 @@ namespace ROS2
 
         transformInterface_->SetWorldTM(transform);
     }
-
 } // namespace ROS2

--- a/Code/Source/Spawner/ROS2SpawnerComponent.cpp
+++ b/Code/Source/Spawner/ROS2SpawnerComponent.cpp
@@ -15,6 +15,16 @@
 
 namespace ROS2
 {
+    ROS2SpawnerComponent::ROS2SpawnerComponent()
+    {
+        SpawnerInterface::Register(this);
+    }
+
+    ROS2SpawnerComponent::~ROS2SpawnerComponent()
+    {
+        SpawnerInterface::Unregister(this);
+    }
+
     void ROS2SpawnerComponent::Activate()
     {
         auto ros2Node = ROS2Interface::Get()->GetNode();
@@ -44,14 +54,22 @@ namespace ROS2
     {
         if (AZ::SerializeContext* serialize = azrtti_cast<AZ::SerializeContext*>(context))
         {
-            serialize->Class<ROS2SpawnerComponent, AZ::Component>()->Version(1)->Field("Spawnables", &ROS2SpawnerComponent::m_spawnables);
+            serialize->Class<ROS2SpawnerComponent, AZ::Component>()
+                ->Version(1)
+                ->Field("Spawnables", &ROS2SpawnerComponent::m_spawnables)
+                ->Field("Default spawn point", &ROS2SpawnerComponent::m_defaultSpawnPoint);
 
             if (AZ::EditContext* ec = serialize->GetEditContext())
             {
                 ec->Class<ROS2SpawnerComponent>("ROS2 Spawner", "Spawner component")
                     ->ClassElement(AZ::Edit::ClassElements::EditorData, "Manages spawning of robots in configurable locations")
                     ->Attribute(AZ::Edit::Attributes::AppearsInAddComponentMenu, AZ_CRC("Game"))
-                    ->DataElement(AZ::Edit::UIHandlers::EntityId, &ROS2SpawnerComponent::m_spawnables, "Spawnables", "Spawnables");
+                    ->DataElement(AZ::Edit::UIHandlers::EntityId, &ROS2SpawnerComponent::m_spawnables, "Spawnables", "Spawnables")
+                    ->DataElement(
+                        AZ::Edit::UIHandlers::EntityId,
+                        &ROS2SpawnerComponent::m_defaultSpawnPoint,
+                        "Default spawn point",
+                        "Default spawn point");
             }
         }
     }
@@ -121,5 +139,10 @@ namespace ROS2
         auto* transformInterface_ = root->FindComponent<AzFramework::TransformComponent>();
 
         transformInterface_->SetWorldTM(transform);
+    }
+
+    const AZ::Vector3& ROS2SpawnerComponent::GetDefaultSpawnPoint() const
+    {
+        return m_defaultSpawnPoint;
     }
 } // namespace ROS2

--- a/Code/Source/Spawner/ROS2SpawnerComponent.h
+++ b/Code/Source/Spawner/ROS2SpawnerComponent.h
@@ -7,6 +7,7 @@
  */
 #pragma once
 
+#include "SpawnerBus.h"
 #include <AzCore/Component/Component.h>
 #include <AzFramework/Spawnable/Spawnable.h>
 #include <AzFramework/Spawnable/SpawnableEntitiesInterface.h>
@@ -23,15 +24,17 @@ namespace ROS2
 
     //! Manages robots spawning.
     //! Allows user to set spawnable prefabs in the Editor and spawn them using ROS2 service during the simulation.
-    class ROS2SpawnerComponent : public AZ::Component
+    class ROS2SpawnerComponent
+        : public AZ::Component
+        , public SpawnerRequestsBus::Handler
     {
     public:
-        AZ_COMPONENT(ROS2SpawnerComponent, "{5950AC6B-75F3-4E0F-BA5C-17C877013710}", AZ::Component);
+        AZ_COMPONENT(ROS2SpawnerComponent, "{5950AC6B-75F3-4E0F-BA5C-17C877013710}", AZ::Component, SpawnerRequestsBus::Handler);
 
         // AZ::Component interface implementation.
-        ROS2SpawnerComponent() = default;
+        ROS2SpawnerComponent();
 
-        ~ROS2SpawnerComponent() = default;
+        ~ROS2SpawnerComponent();
 
         void Activate() override;
 
@@ -40,12 +43,16 @@ namespace ROS2
         // Required Reflect function.
         static void Reflect(AZ::ReflectContext* context);
 
+        const AZ::Vector3& GetDefaultSpawnPoint() const override;
+
     private:
         AZStd::unordered_map<AZStd::string, AZ::Data::Asset<AzFramework::Spawnable>> m_spawnables;
         AZStd::unordered_map<AZStd::string, AzFramework::EntitySpawnTicket> m_tickets;
 
         rclcpp::Service<gazebo_msgs::srv::GetWorldProperties>::SharedPtr m_getNamesService;
         rclcpp::Service<gazebo_msgs::srv::SpawnEntity>::SharedPtr m_spawnService;
+
+        AZ::Vector3 m_defaultSpawnPoint = { 0, 0, 0 };
 
         void GetAvailableSpawnableNames(const GetAvailableSpawnableNamesRequest request, GetAvailableSpawnableNamesResponse response);
 

--- a/Code/Source/Spawner/ROS2SpawnerComponent.h
+++ b/Code/Source/Spawner/ROS2SpawnerComponent.h
@@ -43,7 +43,7 @@ namespace ROS2
         // Required Reflect function.
         static void Reflect(AZ::ReflectContext* context);
 
-        const AZ::Vector3& GetDefaultSpawnPoint() const override;
+        const AZ::Transform& GetDefaultSpawnPose() const override;
 
     private:
         AZStd::unordered_map<AZStd::string, AZ::Data::Asset<AzFramework::Spawnable>> m_spawnables;
@@ -52,7 +52,7 @@ namespace ROS2
         rclcpp::Service<gazebo_msgs::srv::GetWorldProperties>::SharedPtr m_getNamesService;
         rclcpp::Service<gazebo_msgs::srv::SpawnEntity>::SharedPtr m_spawnService;
 
-        AZ::Vector3 m_defaultSpawnPoint = { 0, 0, 0 };
+        AZ::Transform m_defaultSpawnPose = { AZ::Vector3{ 0, 0, 0 }, AZ::Quaternion{ 0, 0, 0, 1 }, 1.0 };
 
         void GetAvailableSpawnableNames(const GetAvailableSpawnableNamesRequest request, GetAvailableSpawnableNamesResponse response);
 

--- a/Code/Source/Spawner/SpawnerBus.h
+++ b/Code/Source/Spawner/SpawnerBus.h
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+#pragma once
+
+#include <AzCore/Component/ComponentBus.h>
+#include <AzCore/EBus/EBus.h>
+#include <AzCore/Math/Vector3.h>
+#include <AzCore/RTTI/BehaviorContext.h>
+
+namespace ROS2
+{
+    //!  Interface class allowing requesting Spawner interface from other components.
+    class SpawnerRequests : public AZ::ComponentBus
+    {
+    public:
+        AZ_RTTI(SpawnerRequests, "{3C42A3A1-1B8E-4800-9473-E4441315D7C8}");
+
+        static constexpr AZ::EBusHandlerPolicy HandlerPolicy = AZ::EBusHandlerPolicy::Single;
+
+        virtual ~SpawnerRequests() = default;
+
+        //! Default spawn point getter
+        //! @return default spawn point coordinates set by user in Editor (by default: {0, 0, 0})
+        virtual const AZ::Vector3& GetDefaultSpawnPoint() const = 0;
+    };
+
+    using SpawnerRequestsBus = AZ::EBus<SpawnerRequests>;
+    using SpawnerInterface = AZ::Interface<SpawnerRequests>;
+} // namespace ROS2

--- a/Code/Source/Spawner/SpawnerBus.h
+++ b/Code/Source/Spawner/SpawnerBus.h
@@ -9,7 +9,7 @@
 
 #include <AzCore/Component/ComponentBus.h>
 #include <AzCore/EBus/EBus.h>
-#include <AzCore/Math/Vector3.h>
+#include <AzCore/Math/Transform.h>
 #include <AzCore/RTTI/BehaviorContext.h>
 
 namespace ROS2
@@ -24,9 +24,10 @@ namespace ROS2
 
         virtual ~SpawnerRequests() = default;
 
-        //! Default spawn point getter
-        //! @return default spawn point coordinates set by user in Editor (by default: {0, 0, 0})
-        virtual const AZ::Vector3& GetDefaultSpawnPoint() const = 0;
+        //! Default spawn pose getter
+        //! @return default spawn point coordinates set by user in Editor (by default: translation: {0, 0, 0}, rotation: {0, 0, 0, 1},
+        //! scale: 1.0)
+        virtual const AZ::Transform& GetDefaultSpawnPose() const = 0;
     };
 
     using SpawnerRequestsBus = AZ::EBus<SpawnerRequests>;

--- a/Code/ros2_files.cmake
+++ b/Code/ros2_files.cmake
@@ -71,4 +71,5 @@ set(FILES
     Source/Converters/URDF/ToFBX/UrdfToFbxConverter.h
     Source/Spawner/ROS2SpawnerComponent.h
     Source/Spawner/ROS2SpawnerComponent.cpp
+    Source/Spawner/SpawnerBus.h
 )

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ This Gem enables users to develop robotic simulations through ROS2 tools and com
 
 Replace `<distro>` with ROS 2 distribution name (galactic, humble, ..).
 
-* gazebo_msgs ( sudo apt install ros-${ROS_DISTRO}-gazebo-msgs)
+* gazebo_msgs ( `sudo apt install ros-${ROS_DISTRO}-gazebo-msgs` )
 
 ## Features
 

--- a/README.md
+++ b/README.md
@@ -9,6 +9,8 @@ This Gem enables users to develop robotic simulations through ROS2 tools and com
 * Modern version of ROS 2. We support and tested with:
   * [ROS 2 Galactic](https://docs.ros.org/en/galactic/Installation.html) with Ubuntu 20.04.
   * [ROS 2 Humble](https://docs.ros.org/en/humble/Installation.html) with Ubuntu 22.04.
+  * Additional ROS2 packages required:
+    * gazebo_msgs ( sudo apt install ros-${ROS_DISTRO}-gazebo-msgs)
 
 #### Additional ros packages required
 

--- a/docs/guides/ros2-gem.md
+++ b/docs/guides/ros2-gem.md
@@ -101,6 +101,7 @@ During the simulation user can access names of available spawnables and request 
   - example call: `ros2 service call /spawn_entity gazebo_msgs/srv/SpawnEntity '{name: 'robot', initial_pose: {position:{ x: 4, y: 4, z: 0.2}, orientation: {x: 0.0, y: 0.0, z: 0.0, w: 1.0}}}'`
 - Available spawnable names access: names of available spawnables are sent in response.model_names
   - example call: `ros2 service call /get_available_spawnable_names gazebo_msgs/srv/GetWorldProperties`
+
 ### Handling custom ROS 2 dependencies
 
 The ROS 2 Gem will respect your choice of [__sourced__](https://docs.ros.org/en/galactic/Tutorials/Workspace/Creating-A-Workspace.html#source-the-overlay) ROS 2 environment.


### PR DESCRIPTION
https://github.com/RobotecAI/o3de-ros2-gem/issues/208

If the ROS2SpawnerComponent was created, URDF Importer will spawn prefab in a default spawn point defined in the spawner component. Otherwise the prefab will be created in a default point (0, 0, 0).