### PR TITLE
ROS2 components are created with Editor wrapper by URDF importer

### DIFF
--- a/Code/Source/Camera/ROS2CameraSensorComponent.cpp
+++ b/Code/Source/Camera/ROS2CameraSensorComponent.cpp
@@ -116,8 +116,8 @@ namespace ROS2
             [this](const AZ::RPI::AttachmentReadback::ReadbackResult& result)
             {
                 const AZ::RHI::ImageDescriptor& descriptor = result.m_imageDescriptor;
-
-                AZStd::string frameName = GetEntity()->FindComponent<ROS2FrameComponent>()->GetFrameID();
+                const auto* component = AzToolsFramework::FindWrappedComponentForEntity<ROS2FrameComponent>(GetEntity());
+                AZStd::string frameName = component->GetFrameID();
                 sensor_msgs::msg::Image message;
                 message.encoding = sensor_msgs::image_encodings::RGBA8;
 

--- a/Code/Source/Frame/ROS2FrameComponent.cpp
+++ b/Code/Source/Frame/ROS2FrameComponent.cpp
@@ -89,7 +89,8 @@ namespace ROS2
         if (AZ::EntityId parentEntityId = GetEntityTransformInterface()->GetParentId(); parentEntityId.IsValid())
         {
             const AZ::Entity* parentEntity = AzToolsFramework::GetEntityById(parentEntityId);
-            return parentEntity->FindComponent<ROS2FrameComponent>();
+            auto* component = AzToolsFramework::FindWrappedComponentForEntity<ROS2FrameComponent>(parentEntity);
+            return component;
         }
         return nullptr;
     }
@@ -127,6 +128,11 @@ namespace ROS2
     AZStd::string ROS2FrameComponent::GetFrameID() const
     {
         return ROS2Names::GetNamespacedName(GetNamespace(), m_frameName);
+    }
+
+    void ROS2FrameComponent::SetFrameID(const AZStd::string& frameId)
+    {
+        m_frameName = frameId;
     }
 
     AZStd::string ROS2FrameComponent::GetNamespace() const

--- a/Code/Source/Frame/ROS2FrameComponent.h
+++ b/Code/Source/Frame/ROS2FrameComponent.h
@@ -12,6 +12,7 @@
 #include <AzCore/Component/Component.h>
 #include <AzCore/std/smart_ptr/unique_ptr.h>
 #include <AzFramework/Components/TransformComponent.h>
+#include <AzToolsFramework/ToolsComponents/GenericComponentWrapper.h>
 
 namespace ROS2
 {
@@ -41,6 +42,9 @@ namespace ROS2
         //! Get a frame id, which is needed for any ROS2 message with a Header
         //! @return Frame id which includes the namespace, ready to send in a ROS2 message
         AZStd::string GetFrameID() const;
+
+        //! Set a above-mentioned frame id
+        void SetFrameID(const AZStd::string& frameId);
 
         //! Get a namespace, which should be used for any publisher or subscriber in the same entity.
         //! @return A complete namespace (including parent namespaces)

--- a/Code/Source/GNSS/ROS2GNSSSensorComponent.cpp
+++ b/Code/Source/GNSS/ROS2GNSSSensorComponent.cpp
@@ -107,7 +107,7 @@ namespace ROS2
 
     AZ::Transform ROS2GNSSSensorComponent::GetCurrentPose() const
     {
-        auto ros2Frame = GetEntity()->FindComponent<ROS2FrameComponent>();
+        auto* ros2Frame = AzToolsFramework::FindWrappedComponentForEntity<ROS2FrameComponent>(GetEntity());
         return ros2Frame->GetFrameTransform();
     }
 } // namespace ROS2

--- a/Code/Source/Imu/ROS2ImuSensorComponent.cpp
+++ b/Code/Source/Imu/ROS2ImuSensorComponent.cpp
@@ -144,7 +144,7 @@ namespace ROS2
 
     AZ::Transform ROS2ImuSensorComponent::GetCurrentPose() const
     {
-        auto ros2Frame = GetEntity()->FindComponent<ROS2FrameComponent>();
+        auto* ros2Frame = AzToolsFramework::FindWrappedComponentForEntity<ROS2FrameComponent>(GetEntity());
         return ros2Frame->GetFrameTransform();
     }
 

--- a/Code/Source/Lidar/ROS2LidarSensorComponent.cpp
+++ b/Code/Source/Lidar/ROS2LidarSensorComponent.cpp
@@ -173,7 +173,7 @@ namespace ROS2
             m_visualisationPoints = m_lastScanResults;
         }
 
-        auto ros2Frame = GetEntity()->FindComponent<ROS2FrameComponent>();
+        auto* ros2Frame = AzToolsFramework::FindWrappedComponentForEntity<ROS2FrameComponent>(GetEntity());
         auto message = sensor_msgs::msg::PointCloud2();
         message.header.frame_id = ros2Frame->GetFrameID().data();
         message.header.stamp = ROS2Interface::Get()->GetROSTimestamp();

--- a/Code/Source/RobotControl/ROS2RobotControlComponent.cpp
+++ b/Code/Source/RobotControl/ROS2RobotControlComponent.cpp
@@ -76,10 +76,22 @@ namespace ROS2
     {
         // TODO - also, dependent on current/selected RobotControl implementation for what components are required
         required.push_back(AZ_CRC("ROS2Frame"));
+        required.push_back(AZ_CRC("PhysicsRigidBodyService"));
+    }
+
+    const ControlConfiguration& ROS2RobotControlComponent::GetControlConfiguration() const
+    {
+        return m_controlConfiguration;
     }
 
     void ROS2RobotControlComponent::GetProvidedServices(AZ::ComponentDescriptor::DependencyArrayType& provided)
     {
         provided.push_back(AZ_CRC_CE("ROS2RobotControl"));
     }
+
+    void ROS2RobotControlComponent::SetControlConfiguration(const ControlConfiguration& controlConfiguration)
+    {
+        m_controlConfiguration = controlConfiguration;
+    }
+
 } // namespace ROS2

--- a/Code/Source/RobotControl/ROS2RobotControlComponent.cpp
+++ b/Code/Source/RobotControl/ROS2RobotControlComponent.cpp
@@ -76,7 +76,6 @@ namespace ROS2
     {
         // TODO - also, dependent on current/selected RobotControl implementation for what components are required
         required.push_back(AZ_CRC("ROS2Frame"));
-        required.push_back(AZ_CRC("PhysicsRigidBodyService"));
     }
 
     const ControlConfiguration& ROS2RobotControlComponent::GetControlConfiguration() const

--- a/Code/Source/RobotControl/ROS2RobotControlComponent.h
+++ b/Code/Source/RobotControl/ROS2RobotControlComponent.h
@@ -11,6 +11,7 @@
 #include "ControlSubscriptionHandler.h"
 #include <AzCore/Component/Component.h>
 #include <AzCore/std/smart_ptr/unique_ptr.h>
+#include <AzToolsFramework/ToolsComponents/GenericComponentWrapper.h>
 
 namespace ROS2
 {
@@ -26,6 +27,10 @@ namespace ROS2
             : m_controlConfiguration(AZStd::move(controlConfiguration))
         {
         }
+
+        const ControlConfiguration& GetControlConfiguration() const;
+
+        void SetControlConfiguration(const ControlConfiguration& controlConfiguration);
 
         // AZ::Component interface implementation.
         void Activate() override;

--- a/Code/Source/RobotImporter/URDF/URDFPrefabMaker.cpp
+++ b/Code/Source/RobotImporter/URDF/URDFPrefabMaker.cpp
@@ -11,12 +11,14 @@
 #include "RobotControl/ROS2RobotControlComponent.h"
 #include "RobotImporter/URDF/CollidersMaker.h"
 #include "RobotImporter/URDF/PrefabMakerUtils.h"
+#include "RobotImporter/Utils/RobotImporterUtils.h"
 #include <API/EditorAssetSystemAPI.h>
 #include <AzCore/IO/FileIO.h>
 #include <AzToolsFramework/Entity/EditorEntityHelpers.h>
 #include <AzToolsFramework/Prefab/PrefabLoaderInterface.h>
 #include <AzToolsFramework/Prefab/PrefabSystemComponentInterface.h>
 #include <AzToolsFramework/ToolsComponents/TransformComponent.h>
+#include <AzToolsFramework/ToolsComponents/GenericComponentWrapper.h>
 
 #include <Spawner/SpawnerBus.h>
 
@@ -112,8 +114,13 @@ namespace ROS2
 
         // Add ROS2FrameComponent - TODO: only for top level and joints
         // TODO - add unique namespace to the robot's top level frame
-        entity->CreateComponent<ROS2FrameComponent>(link->name.c_str());
-
+        const auto frameCompontentId = Utils::CreateComponent(entityId, ROS2FrameComponent::TYPEINFO_Uuid());
+        if (frameCompontentId)
+        {
+            auto* component = AzToolsFramework::FindWrappedComponentForEntity<ROS2FrameComponent>(entity);
+            AZ_Assert(component, "Component not exists for %s", entityId.ToString().c_str());
+            component->SetFrameID(AZStd::string(link->name.c_str(), link->name.size()));
+        }
         m_visualsMaker.AddVisuals(link, entityId);
         m_collidersMaker.AddColliders(link, entityId);
         m_inertialsMaker.AddInertial(link->inertial, entityId);
@@ -138,11 +145,15 @@ namespace ROS2
 
     void URDFPrefabMaker::AddRobotControl(AZ::EntityId rootEntityId)
     {
-        // TODO - check for RigidBody
-        ControlConfiguration controlConfiguration;
-        controlConfiguration.m_topic = "cmd_vel";
-        AZ::Entity* rootEntity = AzToolsFramework::GetEntityById(rootEntityId);
-        rootEntity->CreateComponent<ROS2RobotControlComponent>(controlConfiguration);
+        const auto componentId = Utils::CreateComponent(rootEntityId, ROS2RobotControlComponent::TYPEINFO_Uuid());
+        if (componentId)
+        {
+            ControlConfiguration controlConfiguration;
+            controlConfiguration.m_topic = "cmd_vel";
+            AZ::Entity* rootEntity = AzToolsFramework::GetEntityById(rootEntityId);
+            auto* component = AzToolsFramework::FindWrappedComponentForEntity<ROS2RobotControlComponent>(rootEntity);
+            component->SetControlConfiguration(controlConfiguration);
+        }
     }
 
     const AZStd::string& URDFPrefabMaker::GetPrefabPath() const

--- a/Code/Source/RobotImporter/URDF/URDFPrefabMaker.cpp
+++ b/Code/Source/RobotImporter/URDF/URDFPrefabMaker.cpp
@@ -17,8 +17,8 @@
 #include <AzToolsFramework/Entity/EditorEntityHelpers.h>
 #include <AzToolsFramework/Prefab/PrefabLoaderInterface.h>
 #include <AzToolsFramework/Prefab/PrefabSystemComponentInterface.h>
-#include <AzToolsFramework/ToolsComponents/TransformComponent.h>
 #include <AzToolsFramework/ToolsComponents/GenericComponentWrapper.h>
+#include <AzToolsFramework/ToolsComponents/TransformComponent.h>
 
 #include <Spawner/SpawnerBus.h>
 

--- a/Code/Source/RobotImporter/Utils/RobotImporterUtils.cpp
+++ b/Code/Source/RobotImporter/Utils/RobotImporterUtils.cpp
@@ -7,7 +7,7 @@
  */
 #include "RobotImporterUtils.h"
 #include <AzCore/std/string/regex.h>
-
+#include <AzToolsFramework/API/EntityCompositionRequestBus.h>
 namespace ROS2
 {
 
@@ -38,6 +38,31 @@ namespace ROS2
             return true;
         }
         return false;
+    }
+
+    AZ::ComponentId Utils::CreateComponent(const AZ::EntityId entityId, const AZ::Uuid componentType)
+    {
+        AZ::ComponentTypeList componentsToAdd{ componentType };
+        AZStd::vector<AZ::EntityId> entityIds{ entityId };
+        AzToolsFramework::EntityCompositionRequests::AddComponentsOutcome addComponentsOutcome = AZ::Failure(AZStd::string());
+        AzToolsFramework::EntityCompositionRequestBus::BroadcastResult(
+            addComponentsOutcome, &AzToolsFramework::EntityCompositionRequests::AddComponentsToEntities, entityIds, componentsToAdd);
+        if (!addComponentsOutcome.IsSuccess())
+        {
+            AZ_Warning(
+                "URDF importer",
+                false,
+                "Failed to create component %s, entity %s : %s",
+                componentType.ToString<AZStd::string>().c_str(),
+                entityId.ToString().c_str(),
+                addComponentsOutcome.GetError().c_str());
+        }
+        const auto& added = addComponentsOutcome.GetValue().at(entityId).m_componentsAdded;
+        if (added.size())
+        {
+            return added.front()->GetId();
+        }
+        return AZ::InvalidComponentId;
     }
 
 } // namespace ROS2

--- a/Code/Source/RobotImporter/Utils/RobotImporterUtils.h
+++ b/Code/Source/RobotImporter/Utils/RobotImporterUtils.h
@@ -14,5 +14,12 @@ namespace ROS2
     namespace Utils
     {
         bool IsWheelURDFHeuristics(const urdf::LinkConstSharedPtr& link);
-    }
+
+        /// Create component for given entity in safe way.
+        /// \param entityId entity that will own component
+        /// \param componentType Uuid of component to create
+        /// \return created componentId, if fails returns invalid id
+        AZ::ComponentId CreateComponent(const AZ::EntityId entityId, const AZ::Uuid componentType);
+
+    } // namespace Utils
 } // namespace ROS2

--- a/Code/Source/RobotImporter/Utils/RobotImporterUtils.h
+++ b/Code/Source/RobotImporter/Utils/RobotImporterUtils.h
@@ -7,6 +7,7 @@
  */
 #pragma once
 
+#include "AzCore/Component/ComponentBus.h"
 #include "AzCore/std/string/string.h"
 #include "RobotImporter/URDF/UrdfParser.h"
 namespace ROS2
@@ -15,10 +16,10 @@ namespace ROS2
     {
         bool IsWheelURDFHeuristics(const urdf::LinkConstSharedPtr& link);
 
-        /// Create component for given entity in safe way.
+        /// Create component for a given entity in safe way.
         /// \param entityId entity that will own component
         /// \param componentType Uuid of component to create
-        /// \return created componentId, if fails returns invalid id
+        /// \return created componentId, if it fails, it returns invalid id
         AZ::ComponentId CreateComponent(const AZ::EntityId entityId, const AZ::Uuid componentType);
 
     } // namespace Utils

--- a/Code/Source/Sensor/ROS2SensorComponent.cpp
+++ b/Code/Source/Sensor/ROS2SensorComponent.cpp
@@ -52,13 +52,13 @@ namespace ROS2
     AZStd::string ROS2SensorComponent::GetNamespace() const
     {
         // TODO - hold frame?
-        auto ros2Frame = GetEntity()->FindComponent<ROS2FrameComponent>();
+        auto* ros2Frame = AzToolsFramework::FindWrappedComponentForEntity<ROS2FrameComponent>(GetEntity());
         return ros2Frame->GetNamespace();
     };
 
     AZStd::string ROS2SensorComponent::GetFrameID() const
     {
-        auto ros2Frame = GetEntity()->FindComponent<ROS2FrameComponent>();
+        auto* ros2Frame = AzToolsFramework::FindWrappedComponentForEntity<ROS2FrameComponent>(GetEntity());
         return ros2Frame->GetFrameID();
     }
 


### PR DESCRIPTION
The components created by URDF importer are created in a safe way and are wrapped in GenericComponentWrapper.

Signed-off-by: Michał Pełka <michalpelka@gmail.com>