### PR TITLE
Fix compilation errors from new roscon_2022 branch

### DIFF
--- a/Code/CMakeLists.txt
+++ b/Code/CMakeLists.txt
@@ -133,6 +133,8 @@ if(PAL_TRAIT_BUILD_TESTS_SUPPORTED)
             NAMESPACE Gem
             FILES_CMAKE
                 ros2_tests_files.cmake
+            PLATFORM_INCLUDE_FILES
+                ${CMAKE_CURRENT_LIST_DIR}/Platform/Common/${PAL_TRAIT_COMPILER_ID}/ros2_static_${PAL_TRAIT_COMPILER_ID_LOWERCASE}.cmake
             INCLUDE_DIRECTORIES
                 PRIVATE
                     Tests
@@ -158,6 +160,8 @@ if(PAL_TRAIT_BUILD_TESTS_SUPPORTED)
                 NAMESPACE Gem
                 FILES_CMAKE
                     ros2_editor_tests_files.cmake
+                PLATFORM_INCLUDE_FILES
+                    ${CMAKE_CURRENT_LIST_DIR}/Platform/Common/${PAL_TRAIT_COMPILER_ID}/ros2_static_${PAL_TRAIT_COMPILER_ID_LOWERCASE}.cmake
                 INCLUDE_DIRECTORIES
                     PRIVATE
                         Tests

--- a/Code/Source/Camera/CameraSensor.cpp
+++ b/Code/Source/Camera/CameraSensor.cpp
@@ -132,7 +132,7 @@ namespace ROS2
         AZ::Transform inverse = cameraPose.GetInverse();
         m_view->SetWorldToViewMatrix(AZ::Matrix4x4::CreateFromQuaternionAndTranslation(inverse.GetRotation(), inverse.GetTranslation()));
 
-        size_t userId = AZ::Render::FrameCaptureRequests::s_InvalidFrameCaptureId;
+        size_t userId = AZ::Render::InvalidFrameCaptureId;
 
         m_pipeline->AddToRenderTickOnce();
         AZ::Render::FrameCaptureRequestBus::BroadcastResult(


### PR DESCRIPTION
Fixes

```
In file included from /home/github/o3de-demo-project/build/linux/External/o3de-ros2-gem-3cf121f3/Code/CMakeFiles/ROS2.Static.dir/Unity/unity_0_cxx.cxx:3:
/home/github/o3de-ros2-gem/Code/Source/Camera/CameraSensor.cpp:135:25: error: no member named 's_InvalidFrameCaptureId' in 'AZ::Render::FrameCaptureRequests'; did you mean 'AZ::Render::InvalidFrameCaptureId'?
        size_t userId = AZ::Render::FrameCaptureRequests::s_InvalidFrameCaptureId;
                        ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
                        AZ::Render::InvalidFrameCaptureId
/home/github/o3de/Gems/Atom/Feature/Common/Code/Include/Atom/Feature/Utils/FrameCaptureBus.h:31:34: note: 'AZ::Render::InvalidFrameCaptureId' declared here
        constexpr FrameCaptureId InvalidFrameCaptureId = aznumeric_cast<FrameCaptureId>(-1);
                                 ^
1 error generated.
```

```
In file included from /home/github/o3de-demo-project/build/linux/External/o3de-ros2-gem-3cf121f3/Code/CMakeFiles/ROS2.Tests.dir/Unity/unity_0_cxx.cxx:5:
In file included from /home/github/o3de-ros2-gem/Code/Tests/UrdfParserTest.cpp:9:
In file included from /home/github/o3de-ros2-gem/Code/Source/RobotImporter/Utils/RobotImporterUtils.h:11:
In file included from /home/github/o3de-ros2-gem/Code/Source/RobotImporter/URDF/UrdfParser.h:12:
In file included from /opt/ros/humble/lib/x86_64-linux-gnu/urdfdom/cmake/../../../../include/urdfdom/urdf_parser/urdf_parser.h:45:
In file included from /opt/ros/humble/lib/x86_64-linux-gnu/urdfdom_headers/cmake/../../../../include/urdfdom_headers/urdf_model/model.h:42:
In file included from /opt/ros/humble/lib/x86_64-linux-gnu/urdfdom_headers/cmake/../../../../include/urdfdom_headers/urdf_model/link.h:44:
In file included from /opt/ros/humble/lib/x86_64-linux-gnu/urdfdom_headers/cmake/../../../../include/urdfdom_headers/urdf_model/joint.h:43:
In file included from /opt/ros/humble/lib/x86_64-linux-gnu/urdfdom_headers/cmake/../../../../include/urdfdom_headers/urdf_model/pose.h:47:
/opt/ros/humble/lib/x86_64-linux-gnu/urdfdom_headers/cmake/../../../../include/urdfdom_headers/urdf_model/utils.h:84:5: error: cannot use 'throw' with exceptions disabled
    throw std::runtime_error("Failed converting string to double");
```

Signed-off-by: Steve Pham <82231385+spham-amzn@users.noreply.github.com>