### PR TITLE
Vehicle debug output

### DIFF
--- a/Code/Source/VehicleDynamics/DriveModels/SimplifiedDriveModel.cpp
+++ b/Code/Source/VehicleDynamics/DriveModels/SimplifiedDriveModel.cpp
@@ -46,7 +46,9 @@ namespace VehicleDynamics
                         "Configuration of speed PID controller")
                     ->DataElement(AZ::Edit::UIHandlers::Default, 
                         &SimplifiedDriveModel::maxSpeedImpulse, 
-                        "Max speed impulse", "Speed torque impulse limit [0, INF]. Set to 0.0 to disable.")
+                        "Maximum wheel torque", "Maximum torque force that can be applied to wheels regardless of controller output [0, INF]."
+                        " Set to 0.0 to disable this limit.")
+                    ->Attribute(AZ::Edit::Attributes::Min, 0.0f)
                     ->DataElement(AZ::Edit::UIHandlers::Default, 
                         &SimplifiedDriveModel::showSteeringDebugInfo, "Show steering debug messages", "")
                     ->DataElement(AZ::Edit::UIHandlers::Default, 
@@ -110,7 +112,7 @@ namespace VehicleDynamics
 
             if (showSteeringDebugInfo)
             {
-                AZ_Warning("ApplySteering", false, "Steering target: %f current: %f impulse: %f", steering, currentSteeringAngle, pidCommand);
+                AZ_TracePrintf("ApplySteering", false, "Steering target: %f current: %f impulse: %f", steering, currentSteeringAngle, pidCommand);
             }            
         }
     }
@@ -150,13 +152,13 @@ namespace VehicleDynamics
                 continue;
             }
 
-            if (maxSpeedImpulse>0.0)
+            if (maxSpeedImpulse > 0.0)
             {
-                if (pidCommand>maxSpeedImpulse)
+                if (pidCommand > maxSpeedImpulse)
                 {
                     pidCommand = maxSpeedImpulse;
                 }
-                if (pidCommand<-maxSpeedImpulse)
+                if (pidCommand < -maxSpeedImpulse)
                 {
                     pidCommand = -maxSpeedImpulse;
                 }
@@ -169,7 +171,7 @@ namespace VehicleDynamics
 
             if (showSpeedDebugInfo)
             {
-                AZ_Warning("ApplySpeed", false, "Speed target: %f current: %f impulse: %f", desiredAngularSpeedX, currentAngularSpeedX, pidCommand);
+                AZ_TracePrintf("ApplySpeed", false, "Speed target: %f current: %f impulse: %f", desiredAngularSpeedX, currentAngularSpeedX, pidCommand);
             }            
         }
     }

--- a/Code/Source/VehicleDynamics/DriveModels/SimplifiedDriveModel.cpp
+++ b/Code/Source/VehicleDynamics/DriveModels/SimplifiedDriveModel.cpp
@@ -25,9 +25,7 @@ namespace VehicleDynamics
                 ->Version(1)
                 ->Field("SteeringPID", &SimplifiedDriveModel::m_steeringPid)
                 ->Field("SpeedPID", &SimplifiedDriveModel::m_speedPid)
-                ->Field("MaxSpeedImpulse", &SimplifiedDriveModel::maxSpeedImpulse)
-                ->Field("ShowSteeringDebugInfo", &SimplifiedDriveModel::showSteeringDebugInfo)
-                ->Field("ShowSpeedDebugInfo", &SimplifiedDriveModel::showSpeedDebugInfo);
+                ->Field("MaxSpeedImpulse", &SimplifiedDriveModel::maxSpeedImpulse);
 
 
             if (AZ::EditContext* ec = serialize->GetEditContext())
@@ -46,13 +44,10 @@ namespace VehicleDynamics
                         "Configuration of speed PID controller")
                     ->DataElement(AZ::Edit::UIHandlers::Default, 
                         &SimplifiedDriveModel::maxSpeedImpulse, 
-                        "Maximum wheel torque", "Maximum torque force that can be applied to wheels regardless of controller output [0, INF]."
-                        " Set to 0.0 to disable this limit.")
-                    ->Attribute(AZ::Edit::Attributes::Min, 0.0f)
-                    ->DataElement(AZ::Edit::UIHandlers::Default, 
-                        &SimplifiedDriveModel::showSteeringDebugInfo, "Show steering debug messages", "")
-                    ->DataElement(AZ::Edit::UIHandlers::Default, 
-                        &SimplifiedDriveModel::showSpeedDebugInfo, "Show speed debug messages", "");
+                        "Maximum wheel torque", 
+                        "Maximum torque force (per 1 second) that can be applied to wheels regardless of controller "
+                        "output [0, INF]. Set to 0.0 to disable this limit.")
+                    ->Attribute(AZ::Edit::Attributes::Min, 0.0f);
             }
         }
     }
@@ -109,11 +104,6 @@ namespace VehicleDynamics
             AZ::TransformBus::EventResult(steeringElementTransform, steeringEntity, &AZ::TransformBus::Events::GetWorldTM);
             auto transformedTorqueVector = steeringElementTransform.TransformVector(steeringElementData.m_turnAxis * torque);
             Physics::RigidBodyRequestBus::Event(steeringEntity, &Physics::RigidBodyRequests::ApplyAngularImpulse, transformedTorqueVector);
-
-            if (showSteeringDebugInfo)
-            {
-                AZ_TracePrintf("ApplySteering", false, "Steering target: %f current: %f impulse: %f", steering, currentSteeringAngle, pidCommand);
-            }            
         }
     }
 
@@ -168,11 +158,6 @@ namespace VehicleDynamics
 
             auto transformedTorqueVector = wheelTransform.TransformVector(wheelData.m_driveAxis * impulse);
             Physics::RigidBodyRequestBus::Event(wheelEntity, &Physics::RigidBodyRequests::ApplyAngularImpulse, transformedTorqueVector);
-
-            if (showSpeedDebugInfo)
-            {
-                AZ_TracePrintf("ApplySpeed", false, "Speed target: %f current: %f impulse: %f", desiredAngularSpeedX, currentAngularSpeedX, pidCommand);
-            }            
         }
     }
 } // namespace VehicleDynamics

--- a/Code/Source/VehicleDynamics/DriveModels/SimplifiedDriveModel.cpp
+++ b/Code/Source/VehicleDynamics/DriveModels/SimplifiedDriveModel.cpp
@@ -25,7 +25,9 @@ namespace VehicleDynamics
                 ->Version(1)
                 ->Field("SteeringPID", &SimplifiedDriveModel::m_steeringPid)
                 ->Field("SpeedPID", &SimplifiedDriveModel::m_speedPid)
-                ->Field("MaxSpeedImpulse", &SimplifiedDriveModel::maxSpeedImpulse);
+                ->Field("MaxSpeedImpulse", &SimplifiedDriveModel::maxSpeedImpulse)
+                ->Field("ShowSteeringDebugInfo", &SimplifiedDriveModel::showSteeringDebugInfo)
+                ->Field("ShowSpeedDebugInfo", &SimplifiedDriveModel::showSpeedDebugInfo);
 
             if (AZ::EditContext* ec = serialize->GetEditContext())
             {
@@ -45,9 +47,13 @@ namespace VehicleDynamics
                         AZ::Edit::UIHandlers::Default,
                         &SimplifiedDriveModel::maxSpeedImpulse,
                         "Maximum wheel torque",
-                        "Maximum torque force (per 1 second) that can be applied to wheels regardless of controller "
-                        "output [0, INF]. Set to 0.0 to disable this limit.")
-                    ->Attribute(AZ::Edit::Attributes::Min, 0.0f);
+                        "Maximum torque force that can be applied to wheels regardless of controller output [0, INF]."
+                        " Set to 0.0 to disable this limit.")
+                    ->Attribute(AZ::Edit::Attributes::Min, 0.0f)
+                    ->DataElement(
+                        AZ::Edit::UIHandlers::Default, &SimplifiedDriveModel::showSteeringDebugInfo, "Show steering debug messages", "")
+                    ->DataElement(
+                        AZ::Edit::UIHandlers::Default, &SimplifiedDriveModel::showSpeedDebugInfo, "Show speed debug messages", "");
             }
         }
     }
@@ -104,6 +110,11 @@ namespace VehicleDynamics
             AZ::TransformBus::EventResult(steeringElementTransform, steeringEntity, &AZ::TransformBus::Events::GetWorldTM);
             auto transformedTorqueVector = steeringElementTransform.TransformVector(steeringElementData.m_turnAxis * torque);
             Physics::RigidBodyRequestBus::Event(steeringEntity, &Physics::RigidBodyRequests::ApplyAngularImpulse, transformedTorqueVector);
+
+            if (showSteeringDebugInfo)
+            {
+                AZ_TracePrintf("ApplySteering", "Steering: target: %f current: %f impulse: %f", steering, currentSteeringAngle, pidCommand);
+            }
         }
     }
 
@@ -158,6 +169,12 @@ namespace VehicleDynamics
 
             auto transformedTorqueVector = wheelTransform.TransformVector(wheelData.m_driveAxis * impulse);
             Physics::RigidBodyRequestBus::Event(wheelEntity, &Physics::RigidBodyRequests::ApplyAngularImpulse, transformedTorqueVector);
+
+            if (showSpeedDebugInfo)
+            {
+                AZ_TracePrintf(
+                    "ApplySpeed", "Speed: target: %f current: %f impulse: %f", desiredAngularSpeedX, currentAngularSpeedX, pidCommand);
+            }
         }
     }
 } // namespace VehicleDynamics

--- a/Code/Source/VehicleDynamics/DriveModels/SimplifiedDriveModel.cpp
+++ b/Code/Source/VehicleDynamics/DriveModels/SimplifiedDriveModel.cpp
@@ -27,7 +27,6 @@ namespace VehicleDynamics
                 ->Field("SpeedPID", &SimplifiedDriveModel::m_speedPid)
                 ->Field("MaxSpeedImpulse", &SimplifiedDriveModel::maxSpeedImpulse);
 
-
             if (AZ::EditContext* ec = serialize->GetEditContext())
             {
                 ec->Class<SimplifiedDriveModel>("Simplified Drive Model", "Configuration of a simplified vehicle dynamics drive model")
@@ -42,9 +41,10 @@ namespace VehicleDynamics
                         &SimplifiedDriveModel::m_speedPid,
                         "Speed PID",
                         "Configuration of speed PID controller")
-                    ->DataElement(AZ::Edit::UIHandlers::Default, 
-                        &SimplifiedDriveModel::maxSpeedImpulse, 
-                        "Maximum wheel torque", 
+                    ->DataElement(
+                        AZ::Edit::UIHandlers::Default,
+                        &SimplifiedDriveModel::maxSpeedImpulse,
+                        "Maximum wheel torque",
                         "Maximum torque force (per 1 second) that can be applied to wheels regardless of controller "
                         "output [0, INF]. Set to 0.0 to disable this limit.")
                     ->Attribute(AZ::Edit::Attributes::Min, 0.0f);

--- a/Code/Source/VehicleDynamics/DriveModels/SimplifiedDriveModel.h
+++ b/Code/Source/VehicleDynamics/DriveModels/SimplifiedDriveModel.h
@@ -40,7 +40,7 @@ namespace VehicleDynamics
         PidConfiguration m_steeringPid;
         PidConfiguration m_speedPid;
 
-        float maxSpeedImpulse = 0.0f;
+        float maxSpeedImpulse = 0.0f; // Zero means, the imuplse limit is disabled
 
         bool showSteeringDebugInfo = false;
         bool showSpeedDebugInfo = false;        

--- a/Code/Source/VehicleDynamics/DriveModels/SimplifiedDriveModel.h
+++ b/Code/Source/VehicleDynamics/DriveModels/SimplifiedDriveModel.h
@@ -41,8 +41,6 @@ namespace VehicleDynamics
         PidConfiguration m_speedPid;
 
         float maxSpeedImpulse = 0.0f; // Zero means, the imuplse limit is disabled
-
-        bool showSteeringDebugInfo = false;
-        bool showSpeedDebugInfo = false;        
+    
     };
 } // namespace VehicleDynamics

--- a/Code/Source/VehicleDynamics/DriveModels/SimplifiedDriveModel.h
+++ b/Code/Source/VehicleDynamics/DriveModels/SimplifiedDriveModel.h
@@ -41,5 +41,8 @@ namespace VehicleDynamics
         PidConfiguration m_speedPid;
 
         float maxSpeedImpulse = 0.0f; // Zero means, the imuplse limit is disabled
+
+        bool showSteeringDebugInfo = false;
+        bool showSpeedDebugInfo = false;
     };
 } // namespace VehicleDynamics

--- a/Code/Source/VehicleDynamics/DriveModels/SimplifiedDriveModel.h
+++ b/Code/Source/VehicleDynamics/DriveModels/SimplifiedDriveModel.h
@@ -41,6 +41,5 @@ namespace VehicleDynamics
         PidConfiguration m_speedPid;
 
         float maxSpeedImpulse = 0.0f; // Zero means, the imuplse limit is disabled
-    
     };
 } // namespace VehicleDynamics

--- a/Code/Source/VehicleDynamics/DriveModels/SimplifiedDriveModel.h
+++ b/Code/Source/VehicleDynamics/DriveModels/SimplifiedDriveModel.h
@@ -39,5 +39,10 @@ namespace VehicleDynamics
         AZStd::vector<SteeringDynamicsData> m_steeringData;
         PidConfiguration m_steeringPid;
         PidConfiguration m_speedPid;
+
+        float maxSpeedImpulse = 0.0f;
+
+        bool showSteeringDebugInfo = false;
+        bool showSpeedDebugInfo = false;        
     };
 } // namespace VehicleDynamics


### PR DESCRIPTION
Printing debug information for speed and steering (useful for PID tuning). Can be turned on/off using switches in the GUI.