### PR TITLE
Limit PID output

### DIFF
--- a/Code/Source/VehicleDynamics/DriveModels/PidConfiguration.h
+++ b/Code/Source/VehicleDynamics/DriveModels/PidConfiguration.h
@@ -37,7 +37,7 @@ namespace VehicleDynamics
         double m_iMax = 10.0; //!< maximal allowable integral term
         double m_iMin = -10.0; //!< minimal allowable integral term
         bool m_antiWindup = false; //!< prevents condition of integrator overflow in integral action
-        double m_outputLimit = 0.0; //!< prevents condition of integrator overflow in integral action
+        double m_outputLimit = 0.0; //!< limit PID output; set to 0.0 to disable
 
         control_toolbox::Pid m_pid;
     };

--- a/Code/Source/VehicleDynamics/DriveModels/PidConfiguration.h
+++ b/Code/Source/VehicleDynamics/DriveModels/PidConfiguration.h
@@ -37,6 +37,7 @@ namespace VehicleDynamics
         double m_iMax = 10.0; //!< maximal allowable integral term
         double m_iMin = -10.0; //!< minimal allowable integral term
         bool m_antiWindup = false; //!< prevents condition of integrator overflow in integral action
+        double m_outputLimit = 0.0; //!< prevents condition of integrator overflow in integral action
 
         control_toolbox::Pid m_pid;
     };


### PR DESCRIPTION
More elegant and universal solution for limiting PID output (as #239), suggested by @adamdbrw. 

Added output limit to the PID object, with GUI control. The limit can be applied to all controllers using PID (vehicle steering and speed).

This PR replaces #239.