### PR TITLE
Added routine to access components without specifying if wrapped

### DIFF
--- a/Code/Source/Camera/CameraSensor.h
+++ b/Code/Source/Camera/CameraSensor.h
@@ -7,6 +7,7 @@
  */
 #pragma once
 
+#include "ROS2GemUtilities.h"
 #include <Atom/Feature/Utils/FrameCaptureBus.h>
 #include <chrono>
 

--- a/Code/Source/Camera/ROS2CameraSensorComponent.cpp
+++ b/Code/Source/Camera/ROS2CameraSensorComponent.cpp
@@ -116,7 +116,7 @@ namespace ROS2
             [this](const AZ::RPI::AttachmentReadback::ReadbackResult& result)
             {
                 const AZ::RHI::ImageDescriptor& descriptor = result.m_imageDescriptor;
-                const auto* component = AzToolsFramework::FindWrappedComponentForEntity<ROS2FrameComponent>(GetEntity());
+                const auto* component = Utils::GetGameOrEditorComponent<ROS2FrameComponent>(GetEntity());
                 AZStd::string frameName = component->GetFrameID();
                 sensor_msgs::msg::Image message;
                 message.encoding = sensor_msgs::image_encodings::RGBA8;

--- a/Code/Source/Frame/ROS2FrameComponent.cpp
+++ b/Code/Source/Frame/ROS2FrameComponent.cpp
@@ -89,7 +89,7 @@ namespace ROS2
         if (AZ::EntityId parentEntityId = GetEntityTransformInterface()->GetParentId(); parentEntityId.IsValid())
         {
             const AZ::Entity* parentEntity = AzToolsFramework::GetEntityById(parentEntityId);
-            auto* component = AzToolsFramework::FindWrappedComponentForEntity<ROS2FrameComponent>(parentEntity);
+            auto* component = Utils::GetGameOrEditorComponent<ROS2FrameComponent>(parentEntity);
             return component;
         }
         return nullptr;

--- a/Code/Source/GNSS/ROS2GNSSSensorComponent.cpp
+++ b/Code/Source/GNSS/ROS2GNSSSensorComponent.cpp
@@ -10,6 +10,7 @@
 #include "AzCore/Math/Matrix4x4.h"
 #include "Frame/ROS2FrameComponent.h"
 #include "ROS2/ROS2Bus.h"
+#include "ROS2GemUtilities.h"
 #include "Utilities/ROS2Conversions.h"
 #include "Utilities/ROS2Names.h"
 
@@ -107,7 +108,7 @@ namespace ROS2
 
     AZ::Transform ROS2GNSSSensorComponent::GetCurrentPose() const
     {
-        auto* ros2Frame = AzToolsFramework::FindWrappedComponentForEntity<ROS2FrameComponent>(GetEntity());
+        auto* ros2Frame = Utils::GetGameOrEditorComponent<ROS2FrameComponent>(GetEntity());
         return ros2Frame->GetFrameTransform();
     }
 } // namespace ROS2

--- a/Code/Source/Imu/ROS2ImuSensorComponent.cpp
+++ b/Code/Source/Imu/ROS2ImuSensorComponent.cpp
@@ -144,7 +144,7 @@ namespace ROS2
 
     AZ::Transform ROS2ImuSensorComponent::GetCurrentPose() const
     {
-        auto* ros2Frame = AzToolsFramework::FindWrappedComponentForEntity<ROS2FrameComponent>(GetEntity());
+        auto* ros2Frame = Utils::GetGameOrEditorComponent<ROS2FrameComponent>(GetEntity());
         return ros2Frame->GetFrameTransform();
     }
 

--- a/Code/Source/Lidar/ROS2LidarSensorComponent.cpp
+++ b/Code/Source/Lidar/ROS2LidarSensorComponent.cpp
@@ -173,7 +173,7 @@ namespace ROS2
             m_visualisationPoints = m_lastScanResults;
         }
 
-        auto* ros2Frame = AzToolsFramework::FindWrappedComponentForEntity<ROS2FrameComponent>(GetEntity());
+        auto* ros2Frame = Utils::GetGameOrEditorComponent<ROS2FrameComponent>(GetEntity());
         auto message = sensor_msgs::msg::PointCloud2();
         message.header.frame_id = ros2Frame->GetFrameID().data();
         message.header.stamp = ROS2Interface::Get()->GetROSTimestamp();

--- a/Code/Source/ROS2GemUtilities.cpp
+++ b/Code/Source/ROS2GemUtilities.cpp
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+#include "ROS2GemUtilities.h"
+#include <AzCore/std/string/regex.h>
+#include <AzToolsFramework/API/EntityCompositionRequestBus.h>
+namespace ROS2
+{
+
+    AZ::ComponentId Utils::CreateComponent(const AZ::EntityId entityId, const AZ::Uuid componentType)
+    {
+        AZ::ComponentTypeList componentsToAdd{ componentType };
+        AZStd::vector<AZ::EntityId> entityIds{ entityId };
+        AzToolsFramework::EntityCompositionRequests::AddComponentsOutcome addComponentsOutcome = AZ::Failure(AZStd::string());
+        AzToolsFramework::EntityCompositionRequestBus::BroadcastResult(
+            addComponentsOutcome, &AzToolsFramework::EntityCompositionRequests::AddComponentsToEntities, entityIds, componentsToAdd);
+        if (!addComponentsOutcome.IsSuccess())
+        {
+            AZ_Warning(
+                "URDF importer",
+                false,
+                "Failed to create component %s, entity %s : %s",
+                componentType.ToString<AZStd::string>().c_str(),
+                entityId.ToString().c_str(),
+                addComponentsOutcome.GetError().c_str());
+        }
+        const auto& added = addComponentsOutcome.GetValue().at(entityId).m_componentsAdded;
+        if (added.size())
+        {
+            return added.front()->GetId();
+        }
+        return AZ::InvalidComponentId;
+    }
+
+} // namespace ROS2

--- a/Code/Source/ROS2GemUtilities.h
+++ b/Code/Source/ROS2GemUtilities.h
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+#pragma once
+
+#include "AzCore/Component/ComponentBus.h"
+#include "AzCore/Component/Entity.h"
+#include "AzToolsFramework/ToolsComponents/GenericComponentWrapper.h"
+
+namespace ROS2
+{
+    namespace Utils
+    {
+        /// Create component for a given entity in safe way.
+        /// \param entityId entity that will own component
+        /// \param componentType Uuid of component to create
+        /// \return created componentId, if it fails, it returns invalid id
+        AZ::ComponentId CreateComponent(const AZ::EntityId entityId, const AZ::Uuid componentType);
+
+        /// Retrieve component from entity given by a pointer. It is a way to get game components and wrapped components.
+        /// We should use that that we are not sure if we access e.g. ROS2FrameComponent in game mode or from Editor
+        /// \param entity pointer to entity e.g. with GetEntity()
+        /// \return pointer to component with type T
+
+        template<class ComponentType>
+        ComponentType* GetGameOrEditorComponent(const AZ::Entity* entity)
+        {
+            AZ_Assert(entity, "Called with empty entity");
+            ComponentType* component = entity->FindComponent<ComponentType>();
+            if (component)
+            {
+                return component;
+            }
+            // failed to get game object, let us retry as editor
+            component = AzToolsFramework::FindWrappedComponentForEntity<ComponentType>(entity);
+            AZ_Assert(entity, "Enitity %s has no component of type", entity->GetId());
+            // no component found
+            return nullptr;
+        }
+
+    } // namespace Utils
+} // namespace ROS2

--- a/Code/Source/RobotImporter/URDF/URDFPrefabMaker.cpp
+++ b/Code/Source/RobotImporter/URDF/URDFPrefabMaker.cpp
@@ -8,6 +8,7 @@
 
 #include "RobotImporter/URDF/URDFPrefabMaker.h"
 #include "Frame/ROS2FrameComponent.h"
+#include "ROS2GemUtilities.h"
 #include "RobotControl/ROS2RobotControlComponent.h"
 #include "RobotImporter/URDF/CollidersMaker.h"
 #include "RobotImporter/URDF/PrefabMakerUtils.h"
@@ -117,7 +118,7 @@ namespace ROS2
         const auto frameCompontentId = Utils::CreateComponent(entityId, ROS2FrameComponent::TYPEINFO_Uuid());
         if (frameCompontentId)
         {
-            auto* component = AzToolsFramework::FindWrappedComponentForEntity<ROS2FrameComponent>(entity);
+            auto* component = Utils::GetGameOrEditorComponent<ROS2FrameComponent>(entity);
             AZ_Assert(component, "Component not exists for %s", entityId.ToString().c_str());
             component->SetFrameID(AZStd::string(link->name.c_str(), link->name.size()));
         }
@@ -151,7 +152,7 @@ namespace ROS2
             ControlConfiguration controlConfiguration;
             controlConfiguration.m_topic = "cmd_vel";
             AZ::Entity* rootEntity = AzToolsFramework::GetEntityById(rootEntityId);
-            auto* component = AzToolsFramework::FindWrappedComponentForEntity<ROS2RobotControlComponent>(rootEntity);
+            auto* component = Utils::GetGameOrEditorComponent<ROS2RobotControlComponent>(rootEntity);
             component->SetControlConfiguration(controlConfiguration);
         }
     }

--- a/Code/Source/RobotImporter/Utils/RobotImporterUtils.cpp
+++ b/Code/Source/RobotImporter/Utils/RobotImporterUtils.cpp
@@ -5,9 +5,9 @@
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *
  */
+
 #include "RobotImporterUtils.h"
 #include <AzCore/std/string/regex.h>
-#include <AzToolsFramework/API/EntityCompositionRequestBus.h>
 namespace ROS2
 {
 
@@ -38,31 +38,6 @@ namespace ROS2
             return true;
         }
         return false;
-    }
-
-    AZ::ComponentId Utils::CreateComponent(const AZ::EntityId entityId, const AZ::Uuid componentType)
-    {
-        AZ::ComponentTypeList componentsToAdd{ componentType };
-        AZStd::vector<AZ::EntityId> entityIds{ entityId };
-        AzToolsFramework::EntityCompositionRequests::AddComponentsOutcome addComponentsOutcome = AZ::Failure(AZStd::string());
-        AzToolsFramework::EntityCompositionRequestBus::BroadcastResult(
-            addComponentsOutcome, &AzToolsFramework::EntityCompositionRequests::AddComponentsToEntities, entityIds, componentsToAdd);
-        if (!addComponentsOutcome.IsSuccess())
-        {
-            AZ_Warning(
-                "URDF importer",
-                false,
-                "Failed to create component %s, entity %s : %s",
-                componentType.ToString<AZStd::string>().c_str(),
-                entityId.ToString().c_str(),
-                addComponentsOutcome.GetError().c_str());
-        }
-        const auto& added = addComponentsOutcome.GetValue().at(entityId).m_componentsAdded;
-        if (added.size())
-        {
-            return added.front()->GetId();
-        }
-        return AZ::InvalidComponentId;
     }
 
 } // namespace ROS2

--- a/Code/Source/RobotImporter/Utils/RobotImporterUtils.h
+++ b/Code/Source/RobotImporter/Utils/RobotImporterUtils.h
@@ -16,11 +16,5 @@ namespace ROS2
     {
         bool IsWheelURDFHeuristics(const urdf::LinkConstSharedPtr& link);
 
-        /// Create component for a given entity in safe way.
-        /// \param entityId entity that will own component
-        /// \param componentType Uuid of component to create
-        /// \return created componentId, if it fails, it returns invalid id
-        AZ::ComponentId CreateComponent(const AZ::EntityId entityId, const AZ::Uuid componentType);
-
     } // namespace Utils
 } // namespace ROS2

--- a/Code/Source/Sensor/ROS2SensorComponent.cpp
+++ b/Code/Source/Sensor/ROS2SensorComponent.cpp
@@ -9,6 +9,7 @@
 #include "Sensor/ROS2SensorComponent.h"
 #include "Frame/ROS2FrameComponent.h"
 #include "ROS2/ROS2Bus.h"
+#include "ROS2GemUtilities.h"
 #include "Utilities/ROS2Names.h"
 #include <AzCore/Component/Entity.h>
 #include <AzCore/Serialization/EditContext.h>
@@ -52,13 +53,13 @@ namespace ROS2
     AZStd::string ROS2SensorComponent::GetNamespace() const
     {
         // TODO - hold frame?
-        auto* ros2Frame = AzToolsFramework::FindWrappedComponentForEntity<ROS2FrameComponent>(GetEntity());
+        auto* ros2Frame = Utils::GetGameOrEditorComponent<ROS2FrameComponent>(GetEntity());
         return ros2Frame->GetNamespace();
     };
 
     AZStd::string ROS2SensorComponent::GetFrameID() const
     {
-        auto* ros2Frame = AzToolsFramework::FindWrappedComponentForEntity<ROS2FrameComponent>(GetEntity());
+        auto* ros2Frame = Utils::GetGameOrEditorComponent<ROS2FrameComponent>(GetEntity());
         return ros2Frame->GetFrameID();
     }
 

--- a/Code/ros2_files.cmake
+++ b/Code/ros2_files.cmake
@@ -20,6 +20,8 @@ set(FILES
         Source/Lidar/ROS2LidarSensorComponent.h
         Source/QoS/QoS.cpp
         Source/QoS/QoS.h
+        Source/ROS2GemUtilities.cpp
+        Source/ROS2GemUtilities.h
         Source/RobotControl/ControlConfiguration.cpp
         Source/RobotControl/ControlConfiguration.h
         Source/RobotControl/ControlSubscriptionHandler.h


### PR DESCRIPTION
A lot of components in this Gem are created wrapped in GenericComponentWrapper. Those need to be accessed differently in game mode and editor. `GetGameOrEditorComponent` was added to help with that.

Signed-off-by: Michał Pełka <michalpelka@gmail.com>