### PR TITLE
Named spawn points

### DIFF
--- a/Code/Source/ROS2ModuleInterface.h
+++ b/Code/Source/ROS2ModuleInterface.h
@@ -17,6 +17,7 @@
 #include "RobotControl/Controllers/RigidBodyController/RigidBodyTwistControlComponent.h"
 #include "RobotControl/ROS2RobotControlComponent.h"
 #include "RobotImporter/ROS2RobotImporterSystemComponent.h"
+#include "Spawner/ROS2SpawnPointComponent.h"
 #include "Spawner/ROS2SpawnerComponent.h"
 #include "VehicleDynamics/VehicleModelComponent.h" // TODO - separate out
 #include "VehicleDynamics/WheelControllerComponent.h" // TODO - separate out
@@ -52,6 +53,7 @@ namespace ROS2
                   RigidBodyTwistControlComponent::CreateDescriptor(),
                   ROS2CameraSensorComponent::CreateDescriptor(),
                   ROS2SpawnerComponent::CreateDescriptor(),
+                  ROS2SpawnPointComponent::CreateDescriptor(),
                   VehicleDynamics::VehicleModelComponent::CreateDescriptor(),
                   VehicleDynamics::WheelControllerComponent::CreateDescriptor() });
         }

--- a/Code/Source/Spawner/ROS2SpawnPointComponent.cpp
+++ b/Code/Source/Spawner/ROS2SpawnPointComponent.cpp
@@ -1,0 +1,59 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#include "ROS2SpawnPointComponent.h"
+#include <AzCore/Component/Entity.h>
+#include <AzCore/Serialization/EditContext.h>
+#include <AzFramework/Components/TransformComponent.h>
+#include <AzToolsFramework/UI/PropertyEditor/PropertyEditorAPI.h>
+
+namespace ROS2
+{
+    void ROS2SpawnPointComponent::Activate()
+    {
+    }
+
+    void ROS2SpawnPointComponent::Deactivate()
+    {
+    }
+
+    void ROS2SpawnPointComponent::Reflect(AZ::ReflectContext* context)
+    {
+        if (AZ::SerializeContext* serialize = azrtti_cast<AZ::SerializeContext*>(context))
+        {
+            serialize->Class<ROS2SpawnPointComponent, AZ::Component>()
+                ->Version(1)
+                ->Field("Name", &ROS2SpawnPointComponent::m_name)
+                ->Field("Info", &ROS2SpawnPointComponent::m_info);
+
+            if (AZ::EditContext* ec = serialize->GetEditContext())
+            {
+                ec->Class<ROS2SpawnPointComponent>("ROS2 Spawn Point", "Spawn Point")
+                    ->ClassElement(AZ::Edit::ClassElements::EditorData, "Stores information about available spawn point")
+                    ->Attribute(AZ::Edit::Attributes::AppearsInAddComponentMenu, AZ_CRC("Game"))
+                    ->Attribute(AZ::Edit::Attributes::Category, "ROS2")
+                    ->DataElement(AZ::Edit::UIHandlers::EntityId, &ROS2SpawnPointComponent::m_name, "Name", "Name")
+                    ->DataElement(AZ::Edit::UIHandlers::EntityId, &ROS2SpawnPointComponent::m_info, "Info", "Info");
+            }
+        }
+    }
+
+    AZStd::pair<AZStd::string, SpawnPointInfo> ROS2SpawnPointComponent::GetInfo()
+    {
+        auto transform_component = GetEntity()->FindComponent<AzFramework::TransformComponent>();
+
+        // if SpawnPointComponent entity for some reason does not include TransformComponent - this default pose will be returned
+        AZ::Transform transform = { AZ::Vector3{ 0, 0, 0 }, AZ::Quaternion{ 0, 0, 0, 0 }, 1.0 };
+
+        if (transform_component != nullptr)
+        {
+            transform = transform_component->GetWorldTM();
+        }
+        return { m_name, SpawnPointInfo{ m_info, transform } };
+    }
+} // namespace ROS2

--- a/Code/Source/Spawner/ROS2SpawnPointComponent.cpp
+++ b/Code/Source/Spawner/ROS2SpawnPointComponent.cpp
@@ -38,7 +38,8 @@ namespace ROS2
                     ->Attribute(AZ::Edit::Attributes::AppearsInAddComponentMenu, AZ_CRC("Game"))
                     ->Attribute(AZ::Edit::Attributes::Category, "ROS2")
                     ->DataElement(AZ::Edit::UIHandlers::EntityId, &ROS2SpawnPointComponent::m_name, "Name", "Name")
-                    ->DataElement(AZ::Edit::UIHandlers::EntityId, &ROS2SpawnPointComponent::m_info, "Info", "Info");
+                    ->DataElement(
+                        AZ::Edit::UIHandlers::EntityId, &ROS2SpawnPointComponent::m_info, "Info", "Spawn point detailed description");
             }
         }
     }

--- a/Code/Source/Spawner/ROS2SpawnPointComponent.h
+++ b/Code/Source/Spawner/ROS2SpawnPointComponent.h
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+#pragma once
+
+#include <AzCore/Component/Component.h>
+#include <AzCore/Math/Transform.h>
+namespace ROS2
+{
+    struct SpawnPointInfo
+    {
+        AZStd::string info;
+        AZ::Transform pose;
+    };
+
+    //! SpawnPoint indicates a place which is suitable to spawn a robot.
+    class ROS2SpawnPointComponent : public AZ::Component
+    {
+    public:
+        AZ_COMPONENT(ROS2SpawnPointComponent, "{2AE1CAAE-B300-49FD-8F6D-F7AAABED1EC3}", AZ::Component);
+
+        // AZ::Component interface implementation.
+        ROS2SpawnPointComponent() = default;
+
+        ~ROS2SpawnPointComponent() = default;
+
+        void Activate() override;
+
+        void Deactivate() override;
+
+        // Required Reflect function.
+        static void Reflect(AZ::ReflectContext* context);
+
+        AZStd::pair<AZStd::string, SpawnPointInfo> GetInfo();
+
+    private:
+        AZStd::string m_name;
+        AZStd::string m_info;
+    };
+} // namespace ROS2

--- a/Code/Source/Spawner/ROS2SpawnPointComponent.h
+++ b/Code/Source/Spawner/ROS2SpawnPointComponent.h
@@ -9,6 +9,7 @@
 
 #include <AzCore/Component/Component.h>
 #include <AzCore/Math/Transform.h>
+
 namespace ROS2
 {
     struct SpawnPointInfo

--- a/Code/Source/Spawner/ROS2SpawnerComponent.cpp
+++ b/Code/Source/Spawner/ROS2SpawnerComponent.cpp
@@ -7,10 +7,9 @@
  */
 
 #include "ROS2SpawnerComponent.h"
-#include <AzCore/Math/Quaternion.h>
 #include <AzCore/Serialization/EditContext.h>
 #include <AzFramework/Components/TransformComponent.h>
-#include <AzToolsFramework/UI/PropertyEditor/PropertyEditorAPI.h>
+#include <AzToolsFramework/Entity/EditorEntityHelpers.h>
 #include <ROS2/ROS2Bus.h>
 
 namespace ROS2
@@ -29,7 +28,7 @@ namespace ROS2
     {
         auto ros2Node = ROS2Interface::Get()->GetNode();
 
-        m_getNamesService = ros2Node->create_service<gazebo_msgs::srv::GetWorldProperties>(
+        m_getSpawnablesNamesService = ros2Node->create_service<gazebo_msgs::srv::GetWorldProperties>(
             "get_available_spawnable_names",
             [this](const GetAvailableSpawnableNamesRequest request, GetAvailableSpawnableNamesResponse response)
             {
@@ -42,12 +41,28 @@ namespace ROS2
             {
                 this->SpawnEntity(request, response);
             });
+
+        m_getSpawnPointInfoService = ros2Node->create_service<gazebo_msgs::srv::GetModelState>(
+            "get_spawn_point_info",
+            [this](const GetSpawnPointInfoRequest request, GetSpawnPointInfoResponse response)
+            {
+                this->GetSpawnPointInfo(request, response);
+            });
+
+        m_getSpawnPointsNamesService = ros2Node->create_service<gazebo_msgs::srv::GetWorldProperties>(
+            "get_spawn_points_names",
+            [this](const GetSpawnPointsNamesRequest request, GetSpawnPointsNamesResponse response)
+            {
+                this->GetSpawnPointsNames(request, response);
+            });
     }
 
     void ROS2SpawnerComponent::Deactivate()
     {
-        m_getNamesService.reset();
+        m_getSpawnablesNamesService.reset();
         m_spawnService.reset();
+        m_getSpawnPointInfoService.reset();
+        m_getSpawnPointsNamesService.reset();
     }
 
     void ROS2SpawnerComponent::Reflect(AZ::ReflectContext* context)
@@ -64,6 +79,7 @@ namespace ROS2
                 ec->Class<ROS2SpawnerComponent>("ROS2 Spawner", "Spawner component")
                     ->ClassElement(AZ::Edit::ClassElements::EditorData, "Manages spawning of robots in configurable locations")
                     ->Attribute(AZ::Edit::Attributes::AppearsInAddComponentMenu, AZ_CRC("Game"))
+                    ->Attribute(AZ::Edit::Attributes::Category, "ROS2")
                     ->DataElement(AZ::Edit::UIHandlers::EntityId, &ROS2SpawnerComponent::m_spawnables, "Spawnables", "Spawnables")
                     ->DataElement(
                         AZ::Edit::UIHandlers::EntityId,
@@ -85,20 +101,23 @@ namespace ROS2
 
     void ROS2SpawnerComponent::SpawnEntity(const SpawnEntityRequest request, SpawnEntityResponse response)
     {
-        AZStd::string_view key(request->name.c_str(), request->name.size());
+        AZStd::string_view spawnable_name(request->name.c_str(), request->name.size());
+        AZStd::string_view spawn_point_name(request->xml.c_str(), request->xml.size());
 
-        if (!m_spawnables.contains(key))
+        auto spawn_points = GetSpawnPoints();
+
+        if (!m_spawnables.contains(spawnable_name))
         {
             response->success = false;
             response->status_message = "Requested spawnable name not found";
             return;
         }
 
-        if (!m_tickets.contains(key))
+        if (!m_tickets.contains(spawnable_name))
         {
             // if a ticket for this spawnable was not created but the spawnable name is correct, create the ticket and then use it to
             // spawn an entity
-            auto spawnable = m_spawnables.find(key);
+            auto spawnable = m_spawnables.find(spawnable_name);
             m_tickets.emplace(spawnable->first, AzFramework::EntitySpawnTicket(spawnable->second));
         }
 
@@ -106,18 +125,33 @@ namespace ROS2
 
         AzFramework::SpawnAllEntitiesOptionalArgs optionalArgs;
 
-        optionalArgs.m_preInsertionCallback = [this, position = request->initial_pose](auto id, auto view)
+        AZ::Transform transform;
+
+        if (spawn_points.contains(spawn_point_name))
         {
-            this->PreSpawn(
-                id,
-                view,
-                AZ::Transform(
-                    AZ::Vector3(position.position.x, position.position.y, position.position.z),
-                    AZ::Quaternion(position.orientation.x, position.orientation.y, position.orientation.z, position.orientation.w),
-                    1.0f));
+            transform = spawn_points.at(spawn_point_name).pose;
+        }
+        else if (spawn_point_name == "default")
+        {
+            transform = m_defaultSpawnPose;
+        }
+        else
+        {
+            transform = { AZ::Vector3(request->initial_pose.position.x, request->initial_pose.position.y, request->initial_pose.position.z),
+                          AZ::Quaternion(
+                              request->initial_pose.orientation.x,
+                              request->initial_pose.orientation.y,
+                              request->initial_pose.orientation.z,
+                              request->initial_pose.orientation.w),
+                          1.0f };
+        }
+
+        optionalArgs.m_preInsertionCallback = [this, transform](auto id, auto view)
+        {
+            this->PreSpawn(id, view, transform);
         };
 
-        spawner->SpawnAllEntities(m_tickets.at(key), optionalArgs);
+        spawner->SpawnAllEntities(m_tickets.at(spawnable_name), optionalArgs);
 
         response->success = true;
     }
@@ -143,5 +177,65 @@ namespace ROS2
     const AZ::Transform& ROS2SpawnerComponent::GetDefaultSpawnPose() const
     {
         return m_defaultSpawnPose;
+    }
+
+    void ROS2SpawnerComponent::GetSpawnPointsNames(
+        const ROS2::GetSpawnPointsNamesRequest request, ROS2::GetSpawnPointsNamesResponse response)
+    {
+        for (auto spawn_point : GetSpawnPoints())
+        {
+            response->model_names.emplace_back(spawn_point.first.c_str());
+        }
+    }
+
+    void ROS2SpawnerComponent::GetSpawnPointInfo(const ROS2::GetSpawnPointInfoRequest request, ROS2::GetSpawnPointInfoResponse response)
+    {
+        const AZStd::string_view key(request->model_name.c_str(), request->model_name.size());
+
+        auto spawn_points = GetSpawnPoints();
+        if (spawn_points.contains(key))
+        {
+            auto info = spawn_points.at(key);
+
+            geometry_msgs::msg::Pose pose;
+            pose.position.x = info.pose.GetTranslation().GetX();
+            pose.position.y = info.pose.GetTranslation().GetY();
+            pose.position.z = info.pose.GetTranslation().GetZ();
+            pose.orientation.x = info.pose.GetRotation().GetX();
+            pose.orientation.y = info.pose.GetRotation().GetY();
+            pose.orientation.z = info.pose.GetRotation().GetZ();
+            pose.orientation.w = info.pose.GetRotation().GetW();
+
+            response->pose = pose;
+            response->status_message = info.info.c_str();
+        }
+        else
+        {
+            response->status_message = "Could not find spawn point with given name: " + request->model_name;
+        }
+    }
+
+    AZStd::unordered_map<AZStd::string, SpawnPointInfo> ROS2SpawnerComponent::GetSpawnPoints()
+    {
+        AZStd::vector<AZ::EntityId> children;
+        AZ::TransformBus::EventResult(children, GetEntityId(), &AZ::TransformBus::Events::GetChildren);
+
+        AZStd::unordered_map<AZStd::string, SpawnPointInfo> result;
+
+        for (const auto child : children)
+        {
+            auto child_entity = AzToolsFramework::GetEntityById(child);
+
+            auto spawn_point = child_entity->FindComponent<ROS2SpawnPointComponent>();
+
+            if (spawn_point == nullptr)
+            {
+                continue;
+            }
+
+            result.insert(spawn_point->GetInfo());
+        }
+
+        return result;
     }
 } // namespace ROS2

--- a/Code/Source/Spawner/ROS2SpawnerComponent.cpp
+++ b/Code/Source/Spawner/ROS2SpawnerComponent.cpp
@@ -102,6 +102,8 @@ namespace ROS2
     void ROS2SpawnerComponent::SpawnEntity(const SpawnEntityRequest request, SpawnEntityResponse response)
     {
         AZStd::string_view spawnable_name(request->name.c_str(), request->name.size());
+        // xml parameter of the request is used here like a regular string and stores name of a spawn point
+        // todo: use xml format in this parameter
         AZStd::string_view spawn_point_name(request->xml.c_str(), request->xml.size());
 
         auto spawn_points = GetSpawnPoints();
@@ -109,7 +111,7 @@ namespace ROS2
         if (!m_spawnables.contains(spawnable_name))
         {
             response->success = false;
-            response->status_message = "Requested spawnable name not found";
+            response->status_message = "Could not find spawnable with given name: " + request->name;
             return;
         }
 
@@ -130,10 +132,6 @@ namespace ROS2
         if (spawn_points.contains(spawn_point_name))
         {
             transform = spawn_points.at(spawn_point_name).pose;
-        }
-        else if (spawn_point_name == "default")
-        {
-            transform = m_defaultSpawnPose;
         }
         else
         {
@@ -236,6 +234,9 @@ namespace ROS2
             result.insert(spawn_point->GetInfo());
         }
 
+        // setting name of spawn point component "default" in a child entity will have no effect since it is overwritten here with the
+        // default spawn pose of spawner
+        result["default"] = SpawnPointInfo{ "Default spawn pose defined in the Editor", m_defaultSpawnPose };
         return result;
     }
 } // namespace ROS2

--- a/Code/Source/Spawner/ROS2SpawnerComponent.h
+++ b/Code/Source/Spawner/ROS2SpawnerComponent.h
@@ -7,10 +7,12 @@
  */
 #pragma once
 
+#include "ROS2SpawnPointComponent.h"
 #include "SpawnerBus.h"
 #include <AzCore/Component/Component.h>
 #include <AzFramework/Spawnable/Spawnable.h>
 #include <AzFramework/Spawnable/SpawnableEntitiesInterface.h>
+#include <gazebo_msgs/srv/get_model_state.hpp>
 #include <gazebo_msgs/srv/get_world_properties.hpp>
 #include <gazebo_msgs/srv/spawn_entity.hpp>
 #include <rclcpp/rclcpp.hpp>
@@ -21,6 +23,10 @@ namespace ROS2
     using GetAvailableSpawnableNamesResponse = std::shared_ptr<gazebo_msgs::srv::GetWorldProperties::Response>;
     using SpawnEntityRequest = std::shared_ptr<gazebo_msgs::srv::SpawnEntity::Request>;
     using SpawnEntityResponse = std::shared_ptr<gazebo_msgs::srv::SpawnEntity::Response>;
+    using GetSpawnPointInfoRequest = std::shared_ptr<gazebo_msgs::srv::GetModelState::Request>;
+    using GetSpawnPointInfoResponse = std::shared_ptr<gazebo_msgs::srv::GetModelState::Response>;
+    using GetSpawnPointsNamesRequest = std::shared_ptr<gazebo_msgs::srv::GetWorldProperties::Request>;
+    using GetSpawnPointsNamesResponse = std::shared_ptr<gazebo_msgs::srv::GetWorldProperties::Response>;
 
     //! Manages robots spawning.
     //! Allows user to set spawnable prefabs in the Editor and spawn them using ROS2 service during the simulation.
@@ -49,8 +55,10 @@ namespace ROS2
         AZStd::unordered_map<AZStd::string, AZ::Data::Asset<AzFramework::Spawnable>> m_spawnables;
         AZStd::unordered_map<AZStd::string, AzFramework::EntitySpawnTicket> m_tickets;
 
-        rclcpp::Service<gazebo_msgs::srv::GetWorldProperties>::SharedPtr m_getNamesService;
+        rclcpp::Service<gazebo_msgs::srv::GetWorldProperties>::SharedPtr m_getSpawnablesNamesService;
+        rclcpp::Service<gazebo_msgs::srv::GetWorldProperties>::SharedPtr m_getSpawnPointsNamesService;
         rclcpp::Service<gazebo_msgs::srv::SpawnEntity>::SharedPtr m_spawnService;
+        rclcpp::Service<gazebo_msgs::srv::GetModelState>::SharedPtr m_getSpawnPointInfoService;
 
         AZ::Transform m_defaultSpawnPose = { AZ::Vector3{ 0, 0, 0 }, AZ::Quaternion{ 0, 0, 0, 1 }, 1.0 };
 
@@ -59,5 +67,11 @@ namespace ROS2
         void SpawnEntity(const SpawnEntityRequest request, SpawnEntityResponse response);
 
         void PreSpawn(AzFramework::EntitySpawnTicket::Id, AzFramework::SpawnableEntityContainerView, const AZ::Transform&);
+
+        void GetSpawnPointsNames(const GetSpawnPointsNamesRequest request, GetSpawnPointsNamesResponse response);
+
+        void GetSpawnPointInfo(const GetSpawnPointInfoRequest request, GetSpawnPointInfoResponse response);
+
+        AZStd::unordered_map<AZStd::string, SpawnPointInfo> GetSpawnPoints();
     };
 } // namespace ROS2

--- a/Code/ros2_files.cmake
+++ b/Code/ros2_files.cmake
@@ -98,5 +98,7 @@ set(FILES
         Source/VehicleDynamics/WheelDynamicsData.h
         Source/Spawner/ROS2SpawnerComponent.h
         Source/Spawner/ROS2SpawnerComponent.cpp
+        Source/Spawner/ROS2SpawnPointComponent.cpp
+        Source/Spawner/ROS2SpawnPointComponent.h
         Source/Spawner/SpawnerBus.h
         )

--- a/docs/guides/ros2-gem.md
+++ b/docs/guides/ros2-gem.md
@@ -26,6 +26,7 @@ You can browse Doxygen-generated documentation on [Gem's GitHub page](https://ro
   - RigidBodyTwistControlComponent
 - __Spawner__
   - ROS2SpawnerComponent
+  - ROS2SpawnPointComponent
 - __Vehicle dynamics__
   - VehicleModelComponent
   - WheelControllerComponent
@@ -162,13 +163,25 @@ It is possible to implement your own control mechanisms with this Component.
 
 `ROS2SpawnerComponent` handles spawning entities during simulation.
 Available spawnables have to be set up as the component's field before the simulation.
+User is able to define named spawn points inside the Editor. This can be done by adding `ROS2SpawnPointComponent` to a child entity of an entity with `ROS2SpawnerComponent`.
 
-During the simulation user can access names of available spawnables and request spawning using ros2 services. The names of services are "/get_available_spawnable_names" and "/spawn_entity" respectivly. GetWorldProperties.srv and SpawnEntity.srv types from gazebo_msgs are used to handle these features.
+During the simulation user can access names of available spawnables and request spawning using ros2 services. 
+The names of services are "/get_available_spawnable_names" and "/spawn_entity" respectivly. 
+GetWorldProperties.srv and SpawnEntity.srv types are used to handle these features.
+In order to request defined spawn points names user can use "/get_spawn_points_names" service with GetWorldProperties.srv type.
+Detailed information about specific spawn point (eg. pose) can be accessed using "get_spawn_point_info" service with GetModelState.srv type.
+All used services types are defined in gazebo_msgs package.
 
 - Spawning: spawnable name should be passed in request.name and the position of entity in request.initial_pose
   - example call: `ros2 service call /spawn_entity gazebo_msgs/srv/SpawnEntity '{name: 'robot', initial_pose: {position:{ x: 4, y: 4, z: 0.2}, orientation: {x: 0.0, y: 0.0, z: 0.0, w: 1.0}}}'`
+- Spawning in defined spawn point: spawnable name should be passed in request.name and the name of the spawn point in request.xml
+  - example call: `ros2 service call /spawn_entity gazebo_msgs/srv/SpawnEntity '{name: 'robot', xml: 'spawn_spot'}'`
 - Available spawnable names access: names of available spawnables are sent in response.model_names
   - example call: `ros2 service call /get_available_spawnable_names gazebo_msgs/srv/GetWorldProperties`
+- Defined spawn points' names access: names of defined points are sent in response.model_names
+  - example call: `ros2 service call /get_spawn_points_names gazebo_msgs/srv/GetWorldProperties`
+- Detailed spawn point info access: spawn point name should be passed in request.model_name. Defined pose is sent in response.pose.
+  - example call: `ros2 service call /get_spawn_point_info gazebo_msgs/srv/GetModelState '{model_name: 'spawn_spot'}'`
 
 ## Handling custom ROS 2 dependencies
 

--- a/docs/guides/ros2-gem.md
+++ b/docs/guides/ros2-gem.md
@@ -166,10 +166,10 @@ Available spawnables have to be set up as the component's field before the simul
 User is able to define named spawn points inside the Editor. This can be done by adding `ROS2SpawnPointComponent` to a child entity of an entity with `ROS2SpawnerComponent`.
 
 During the simulation user can access names of available spawnables and request spawning using ros2 services. 
-The names of services are "/get_available_spawnable_names" and "/spawn_entity" respectivly. 
+The names of services are `/get_available_spawnable_names` and `/spawn_entity` respectivly. 
 GetWorldProperties.srv and SpawnEntity.srv types are used to handle these features.
-In order to request defined spawn points names user can use "/get_spawn_points_names" service with GetWorldProperties.srv type.
-Detailed information about specific spawn point (eg. pose) can be accessed using "get_spawn_point_info" service with GetModelState.srv type.
+In order to request defined spawn points names user can use `/get_spawn_points_names` service with GetWorldProperties.srv type.
+Detailed information about specific spawn point (e.g. pose) can be accessed using `/get_spawn_point_info` service with GetModelState.srv type.
 All used services types are defined in gazebo_msgs package.
 
 - Spawning: spawnable name should be passed in request.name and the position of entity in request.initial_pose


### PR DESCRIPTION
User is able to define named spawn points inside the Editor. This can be done by adding ROS2SpawnPointComponent to a child entity of entity with ROS2SpawnerComponent.