### PR TITLE
Remove unnecessary  category attribute from edit context

### DIFF
--- a/Code/Source/Sensor/ROS2SensorComponent.cpp
+++ b/Code/Source/Sensor/ROS2SensorComponent.cpp
@@ -40,7 +40,6 @@ namespace ROS2
             if (AZ::EditContext* ec = serialize->GetEditContext())
             {
                 ec->Class<ROS2SensorComponent>("ROS2 Sensor", "Base component for sensors")
-                    ->Attribute(AZ::Edit::Attributes::Category, "ROS2")
                     ->DataElement(
                         AZ::Edit::UIHandlers::Default,
                         &ROS2SensorComponent::m_sensorConfiguration,


### PR DESCRIPTION
The 'ROS2' category is already being set by classes that inherit from the ROS2SensorComponent class, and this attribute is causing an error on startup of the gem:

```
AssetBuilder: ==================================================================
AssetBuilder: System: Trace::Assert
AssetBuilder:  /home/ANT.AMAZON.COM/spham/github/o3de/Code/Framework/AzCore/./AzCore/Serialization/EditContext.h(801): (139755180220096) 'EditContext::ClassBuilder *AZ::EditContext::ClassBuilder::Attribute(AZ::Crc32, T) [T = const char *]'
AssetBuilder: System: You can attach attributes only to UiElements!
AssetBuilder: E: You can attach attributes only to UiElements!
AssetBuilder: : AZ::EditContext::ClassBuilder* AZ::EditContext::ClassBuilder::Attribute<char const*>(AZ::Crc32, char const*) (+0x5e) [0x7f1a6201afae]
AssetBuilder: : ROS2::ROS2SensorComponent::Reflect(AZ::ReflectContext*) (+0xea) [0x7f1a62a800ca]
AssetBuilder: : AZ::ComponentDescriptorDefault<ROS2::ROS2SensorComponent>::Reflect(AZ::ReflectContext*) const (+0x16) [0x7f1a61f89226]
AssetBuilder: : void AZStd::Internal::function_util::get_invoker<void (AZ::ReflectContext*), AZStd::Internal::function_util::function_obj_tag, AZStd::allocator>::call<AZ::ComponentApplication::RegisterComponentDescriptor(AZ::ComponentDescriptor const*)::$_5>(AZStd::Inter
AssetBuilder: : AZ::ComponentApplication::RegisterComponentDescriptor(AZ::ComponentDescriptor const*) (+0x74) [0x55ec79a03e34]
AssetBuilder: : void AZ::Internal::EBusContainer<AZ::ComponentApplicationRequests, AZ::ComponentApplicationRequestsEBusTraits, (AZ::EBusAddressPolicy)0, (AZ::EBusHandlerPolicy)0>::Dispatcher<AZ::EBus<AZ::ComponentApplicationRequests, AZ::ComponentApplicationRequestsEBusT
AssetBuilder: : AZ::Outcome<void, AZStd::basic_string<char, AZStd::char_traits<char>, AZStd::allocator> > AZStd::Internal::function_util::get_invoker<AZ::Outcome<void, AZStd::basic_string<char, AZStd::char_traits<char>, AZStd::allocator> > (), AZStd::Internal::function_u
AssetBuilder: : AZ::ModuleManager::LoadDynamicModules(AZStd::vector<AZ::DynamicModuleDescriptor, AZ::AZStdAlloc<AZ::OSAllocator> > const&, AZ::ModuleInitializationSteps, bool) (+0xc0) [0x55ec794aef30]
AssetBuilder: : void AZ::Internal::EBusContainer<AZ::ModuleManagerRequests, AZ::ModuleManagerRequests, (AZ::EBusAddressPolicy)0, (AZ::EBusHandlerPolicy)0>::Dispatcher<AZ::EBus<AZ::ModuleManagerRequests, AZ::ModuleManagerRequests> >::BroadcastResult<AZStd::vector<AZ::Outc
AssetBuilder: : AssetBuilderApplication::StartCommon(AZ::Entity*) (+0x127) [0x55ec790d02a7]
AssetBuilder: : AzFramework::Application::Start(AZ::ComponentApplication::Descriptor const&, AZ::ComponentApplication::StartupParameters const&) (+0x3c) [0x55ec7b8585dc]
AssetBuilder: : AzToolsFramework::ToolsApplication::Start(AZ::ComponentApplication::Descriptor const&, AZ::ComponentApplication::StartupParameters const&) (+0x1b) [0x55ec7a4c7b9b]
AssetBuilder: : main (+0x155) [0x55ec790bbcc5]
AssetBuilder: : __libc_init_first (+0x90) [0x7f1b4a273d90]
AssetBuilder: : __libc_start_main (+0x80) [0x7f1b4a273e40]
AssetBuilder: : _start (+0x25) [0x55ec790bbaa5]

```

Signed-off-by: Steve Pham <82231385+spham-amzn@users.noreply.github.com>