### PR TITLE
Getting ROS2 Frame from any ancestor instead of parent

### DIFF
--- a/Code/Include/ROS2/Frame/ROS2FrameComponent.h
+++ b/Code/Include/ROS2/Frame/ROS2FrameComponent.h
@@ -68,7 +68,6 @@ namespace ROS2
         //! Whether transformation to parent frame can change during the simulation, or is fixed.
         bool IsDynamic() const;
 
-        AZ::TransformInterface* GetEntityTransformInterface() const;
         const ROS2FrameComponent* GetParentROS2FrameComponent() const;
 
         //! If parent entity does not exist or does not have a ROS2FrameComponent, return ROS2 default global frame.


### PR DESCRIPTION
Fixes #270

I tested once that it does not break navigation.
However I am uncertain how you would like to use it, so please test

Signed-off-by: Adam Dabrowski <adam.dabrowski@robotec.ai>