### PR TITLE
Lidar max points

### DIFF
--- a/Code/Source/Lidar/LidarRaycaster.cpp
+++ b/Code/Source/Lidar/LidarRaycaster.cpp
@@ -38,6 +38,7 @@ namespace ROS2
 
         AzPhysics::SceneQueryRequests requests;
         requests.reserve(directions.size());
+        results.reserve(directions.size());
         for (const AZ::Vector3& direction : directions)
         { // NOTE - performance-wise, consider reusing requests
             AZStd::shared_ptr<AzPhysics::RayCastRequest> request = AZStd::make_shared<AzPhysics::RayCastRequest>();
@@ -62,13 +63,25 @@ namespace ROS2
 
         auto* sceneInterface = AZ::Interface<AzPhysics::SceneInterface>::Get();
         auto requestResults = sceneInterface->QuerySceneBatch(m_sceneHandle, requests);
-        for (const auto& requestResult : requestResults)
+        AZ_Assert(requestResults.size() == directions.size(), "request size should be equal to directions size");
+        for (int i = 0; i < requestResults.size(); i++)
         { // TODO - check flag for SceneQuery::ResultFlags::Position
+            const auto& requestResult = requestResults[i];
             if (requestResult.m_hits.size() > 0)
             {
                 results.push_back(requestResult.m_hits[0].m_position);
             }
+            else if (m_addPointsMaxRange)
+            {
+                results.push_back(directions[i] * distance);
+            }
         }
         return results;
     }
+
+    void LidarRaycaster::setAddPointsMaxRange(bool addPointsMaxRange)
+    {
+        m_addPointsMaxRange = addPointsMaxRange;
+    }
+
 } // namespace ROS2

--- a/Code/Source/Lidar/LidarRaycaster.h
+++ b/Code/Source/Lidar/LidarRaycaster.h
@@ -45,7 +45,11 @@ namespace ROS2
             bool ignoreLayer,
             unsigned int ignoredLayerIndex);
 
+        //! If true the raycaster produces points at maximum range, if no obstacle was hit
+        void setAddPointsMaxRange(bool addPointsMaxRange);
+
     private:
         AzPhysics::SceneHandle m_sceneHandle;
+        bool m_addPointsMaxRange{ false };
     };
 } // namespace ROS2

--- a/Code/Source/Lidar/LidarTemplate.cpp
+++ b/Code/Source/Lidar/LidarTemplate.cpp
@@ -25,7 +25,8 @@ namespace ROS2
                 ->Field("Max horizontal angle", &LidarTemplate::m_maxHAngle)
                 ->Field("Min vertical angle", &LidarTemplate::m_minVAngle)
                 ->Field("Max vertical angle", &LidarTemplate::m_maxVAngle)
-                ->Field("Max range", &LidarTemplate::m_maxRange);
+                ->Field("Max range", &LidarTemplate::m_maxRange)
+                ->Field("Max range add points", &LidarTemplate::m_addPointsAtMax);
 
             if (AZ::EditContext* ec = serializeContext->GetEditContext())
             {
@@ -52,7 +53,12 @@ namespace ROS2
                     ->Attribute(AZ::Edit::Attributes::Max, 180.0f)
                     ->DataElement(AZ::Edit::UIHandlers::Default, &LidarTemplate::m_maxRange, "Max range", "Maximum beam range [m]")
                     ->Attribute(AZ::Edit::Attributes::Min, 0.0f)
-                    ->Attribute(AZ::Edit::Attributes::Max, 1000.0f);
+                    ->Attribute(AZ::Edit::Attributes::Max, 1000.0f)
+                    ->DataElement(
+                        AZ::Edit::UIHandlers::Default,
+                        &LidarTemplate::m_addPointsAtMax,
+                        "Points at Max",
+                        "If set true LiDAR will produce points at max range for free space");
             }
         }
     }

--- a/Code/Source/Lidar/LidarTemplate.h
+++ b/Code/Source/Lidar/LidarTemplate.h
@@ -38,5 +38,6 @@ namespace ROS2
         unsigned int m_layers = 0;
         unsigned int m_numberOfIncrements = 0;
         float m_maxRange = 0.0f;
+        bool m_addPointsAtMax = false;
     };
 } // namespace ROS2

--- a/Code/Source/Lidar/ROS2LidarSensorComponent.cpp
+++ b/Code/Source/Lidar/ROS2LidarSensorComponent.cpp
@@ -140,7 +140,7 @@ namespace ROS2
             auto* entityScene = AZ::RPI::Scene::GetSceneForEntityId(GetEntityId());
             m_drawQueue = AZ::RPI::AuxGeomFeatureProcessorInterface::GetDrawQueueForScene(entityScene);
         }
-
+        m_lidarRaycaster.setAddPointsMaxRange(m_lidarParameters.m_addPointsAtMax);
         ROS2SensorComponent::Activate();
     }
 

--- a/Code/Source/Manipulator/MotorizedJoint.cpp
+++ b/Code/Source/Manipulator/MotorizedJoint.cpp
@@ -7,10 +7,10 @@
  */
 
 #include "ROS2/Manipulator/MotorizedJoint.h"
+#include "AzFramework/Physics/Components/SimulatedBodyComponentBus.h"
 #include <AzCore/Component/Entity.h>
 #include <AzCore/Component/TransformBus.h>
 #include <AzCore/Serialization/EditContext.h>
-#include "AzFramework/Physics/Components/SimulatedBodyComponentBus.h"
 #include <AzFramework/Physics/RigidBodyBus.h>
 
 namespace ROS2


### PR DESCRIPTION
A small feature that allows LiDAR to yield points at the maximum range when no obstacle was found.
![Screenshot from 2022-10-13 20-09-24](https://user-images.githubusercontent.com/3209244/195675170-d2008c59-0a9a-47bf-a715-f372821c533c.png)
![Screenshot from 2022-10-13 20-08-57](https://user-images.githubusercontent.com/3209244/195675180-ef422772-36f9-446b-b588-399f8b291f56.png)
