### PR TITLE
Prevent non-linux builds of the ROSGem

### DIFF
--- a/Code/CMakeLists.txt
+++ b/Code/CMakeLists.txt
@@ -3,10 +3,18 @@
 #
 # SPDX-License-Identifier: Apache-2.0 OR MIT
 
-# If no ROS2 is found, no targets are valid for this Gem
 
+# Only allow this gem to be configured on platforms that are currently supported
+include(${CMAKE_CURRENT_SOURCE_DIR}/Platform/${PAL_PLATFORM_NAME}/PAL_${PAL_PLATFORM_NAME_LOWERCASE}.cmake)
+if(NOT PAL_TRAIT_BUILD_ROS2_GEM_SUPPORTED)
+    message(FATAL_ERROR "The ROS2 Gem is not currently supported on ${PAL_PLATFORM_NAME}")
+    return()
+endif()
+
+# If no ROS2 is found, no targets are valid for this Gem
 find_package(ROS2 MODULE)
 if (NOT ROS2_FOUND)
+    message(FATAL_ERROR "Unable to detect a the ROS2 distribution on this system. Make sure it is installed and enabled.")
     return()
 endif()
 

--- a/Code/Platform/Android/PAL_android.cmake
+++ b/Code/Platform/Android/PAL_android.cmake
@@ -1,0 +1,9 @@
+#
+# Copyright (c) Contributors to the Open 3D Engine Project.
+# For complete copyright and license terms please see the LICENSE at the root of this distribution.
+#
+# SPDX-License-Identifier: Apache-2.0 OR MIT
+#
+#
+
+set(PAL_TRAIT_BUILD_ROS2_GEM_SUPPORTED FALSE)

--- a/Code/Platform/Linux/PAL_linux.cmake
+++ b/Code/Platform/Linux/PAL_linux.cmake
@@ -1,0 +1,9 @@
+#
+# Copyright (c) Contributors to the Open 3D Engine Project.
+# For complete copyright and license terms please see the LICENSE at the root of this distribution.
+#
+# SPDX-License-Identifier: Apache-2.0 OR MIT
+#
+#
+
+set(PAL_TRAIT_BUILD_ROS2_GEM_SUPPORTED TRUE)

--- a/Code/Platform/Mac/PAL_mac.cmake
+++ b/Code/Platform/Mac/PAL_mac.cmake
@@ -1,0 +1,9 @@
+#
+# Copyright (c) Contributors to the Open 3D Engine Project.
+# For complete copyright and license terms please see the LICENSE at the root of this distribution.
+#
+# SPDX-License-Identifier: Apache-2.0 OR MIT
+#
+#
+
+set(PAL_TRAIT_BUILD_ROS2_GEM_SUPPORTED FALSE)

--- a/Code/Platform/Windows/PAL_windows.cmake
+++ b/Code/Platform/Windows/PAL_windows.cmake
@@ -1,0 +1,9 @@
+#
+# Copyright (c) Contributors to the Open 3D Engine Project.
+# For complete copyright and license terms please see the LICENSE at the root of this distribution.
+#
+# SPDX-License-Identifier: Apache-2.0 OR MIT
+#
+#
+
+set(PAL_TRAIT_BUILD_ROS2_GEM_SUPPORTED FALSE)

--- a/Code/Platform/iOS/PAL_ios.cmake
+++ b/Code/Platform/iOS/PAL_ios.cmake
@@ -1,0 +1,9 @@
+#
+# Copyright (c) Contributors to the Open 3D Engine Project.
+# For complete copyright and license terms please see the LICENSE at the root of this distribution.
+#
+# SPDX-License-Identifier: Apache-2.0 OR MIT
+#
+#
+
+set(PAL_TRAIT_BUILD_ROS2_GEM_SUPPORTED FALSE)


### PR DESCRIPTION
Add PALification code to restrict this gem to only build on Linux (for now)

Signed-off-by: Steve Pham <82231385+spham-amzn@users.noreply.github.com>