### PR TITLE
Compilation fix from latest o3de/development branch

### DIFF
--- a/.github/workflows/Build.yml
+++ b/.github/workflows/Build.yml
@@ -20,7 +20,7 @@ jobs:
     timeout-minutes: 60
     env:
 #     vv Change the o3de hash (LONG FORMAT!) here to fit the build vv
-      O3DE_SHA: bb79fa363586e907de7c736dee554fbdae6e570d
+      O3DE_SHA: 773da3a12364dc4bbab162798ecc496874c71901
       ROS_DISTRO: galactic
     steps:
       - name: O3DE ROS 2 Gem checkout

--- a/.github/workflows/Build.yml
+++ b/.github/workflows/Build.yml
@@ -20,7 +20,7 @@ jobs:
     timeout-minutes: 60
     env:
 #     vv Change the o3de hash (LONG FORMAT!) here to fit the build vv
-      O3DE_SHA: 773da3a12364dc4bbab162798ecc496874c71901
+      O3DE_SHA: 932a0327a58580028bb4a314b2d464dd974edaef
       ROS_DISTRO: galactic
     steps:
       - name: O3DE ROS 2 Gem checkout

--- a/Code/Source/RobotImporter/URDF/CollidersMaker.cpp
+++ b/Code/Source/RobotImporter/URDF/CollidersMaker.cpp
@@ -176,7 +176,7 @@ namespace ROS2
 
             AZStd::shared_ptr<AZ::SceneAPI::Containers::Scene> scene;
             AZ::SceneAPI::Events::SceneSerializationBus::BroadcastResult(
-                scene, &AZ::SceneAPI::Events::SceneSerialization::LoadScene, azMeshPath.c_str(), AZ::Uuid::CreateNull());
+                scene, &AZ::SceneAPI::Events::SceneSerialization::LoadScene, azMeshPath.c_str(), AZ::Uuid::CreateNull(), "");
             if (!scene)
             {
                 AZ_Error(


### PR DESCRIPTION
Fix compile error caused by ebuse signature change of 'AZ::SceneAPI::Events::SceneSerialization::LoadScene' from commit https://github.com/o3de/o3de/commit/15f5c6633debbfa4bca02cd5aec799b42cf583ba


Error:

```
In file included from /home/github/o3de-ros2-gem/Code/Source/RobotImporter/URDF/CollidersMaker.cpp:9:
In file included from /home/github/o3de/Code/Framework/AzCore/./AzCore/Asset/AssetManagerBus.h:11:
In file included from /home/github/o3de/Code/Framework/AzCore/./AzCore/EBus/EBus.h:21:
In file included from /home/github/o3de/Code/Framework/AzCore/./AzCore/EBus/BusImpl.h:20:
In file included from /home/github/o3de/Code/Framework/AzCore/./AzCore/EBus/Internal/BusContainer.h:15:
In file included from /home/github/o3de/Code/Framework/AzCore/./AzCore/EBus/Internal/Handlers.h:11:
In file included from /home/github/o3de/Code/Framework/AzCore/./AzCore/EBus/Internal/StoragePolicies.h:11:
/home/github/o3de/Code/Framework/AzCore/./AzCore/EBus/Policies.h:404:13: error: no matching function for call to 'invoke'
            AZStd::invoke(func, (*rtCurrent.m_iterator++), args...);
            ^~~~~~~~~~~~~
/home/github/o3de/Code/Framework/AzCore/./AzCore/EBus/Internal/BusContainer.h:1550:25: note: in instantiation of function template specialization 'AZ::EBusRouterPolicy<AZ::EBus<AZ::SceneAPI::Events::SceneSerialization>>::RouteEvent<AZStd::shared_ptr<AZ::SceneAPI::Containers::Scene> (AZ::SceneAPI::Events::SceneSerialization::*&)(const AZStd::basic_string<char> &, AZ::Uuid, const AZStd::basic_string<char> &), const char *&, AZ::Uuid &>' requested here
                        EBUS_DO_ROUTING(*context, nullptr, false, false);
                        ^
/home/github/o3de/Code/Framework/AzCore/./AzCore/EBus/Internal/BusContainer.h:77:41: note: expanded from macro 'EBUS_DO_ROUTING'
            if (local_context.m_routing.RouteEvent(id, isQueued, isReverse, func, args...)) {   \
                                        ^
/home/github/o3de-ros2-gem/Code/Source/RobotImporter/URDF/CollidersMaker.cpp:180:58: note: in instantiation of function template specialization 'AZ::Internal::EBusContainer<AZ::SceneAPI::Events::SceneSerialization, AZ::SceneAPI::Events::SceneSerialization, AZ::EBusAddressPolicy::Single, AZ::EBusHandlerPolicy::Single>::Dispatcher<AZ::EBus<AZ::SceneAPI::Events::SceneSerialization>>::BroadcastResult<AZStd::shared_ptr<AZ::SceneAPI::Containers::Scene>, AZStd::shared_ptr<AZ::SceneAPI::Containers::Scene> (AZ::SceneAPI::Events::SceneSerialization::*)(const AZStd::basic_string<char> &, AZ::Uuid, const AZStd::basic_string<char> &), const char *, AZ::Uuid>' requested here
            AZ::SceneAPI::Events::SceneSerializationBus::BroadcastResult(
                                                         ^
/home/github/o3de/Code/Framework/AzCore/./AzCore/std/function/invoke.h:52:50: note: candidate template ignored: substitution failure [with F = AZStd::shared_ptr<AZ::SceneAPI::Containers::Scene> (AZ::SceneAPI::Events::SceneSerialization::*&)(const AZStd::basic_string<char> &, AZ::Uuid, const AZStd::basic_string<char> &), Args = <AZ::EBusRouterNode<AZ::SceneAPI::Events::SceneSerialization> &, const char *&, AZ::Uuid &>]: no type named 'type' in 'AZStd::invoke_result<AZStd::shared_ptr<AZ::SceneAPI::Containers::Scene> (AZ::SceneAPI::Events::SceneSerialization::*&)(const AZStd::basic_string<char> &, AZ::Uuid, const AZStd::basic_string<char> &), AZ::EBusRouterNode<AZ::SceneAPI::Events::SceneSerialization> &, const char *&, AZ::Uuid &>'
    inline constexpr invoke_result_t<F, Args...> invoke(F&& f, Args&&... args)
                                                 ^
In file included from /home/github/o3de-ros2-gem/Code/Source/RobotImporter/URDF/CollidersMaker.cpp:9:
In file included from /home/github/o3de/Code/Framework/AzCore/./AzCore/Asset/AssetManagerBus.h:11:
In file included from /home/github/o3de/Code/Framework/AzCore/./AzCore/EBus/EBus.h:21:
In file included from /home/github/o3de/Code/Framework/AzCore/./AzCore/EBus/BusImpl.h:20:
In file included from /home/github/o3de/Code/Framework/AzCore/./AzCore/EBus/Internal/BusContainer.h:15:
In file included from /home/github/o3de/Code/Framework/AzCore/./AzCore/EBus/Internal/Handlers.h:11:
In file included from /home/github/o3de/Code/Framework/AzCore/./AzCore/EBus/Internal/StoragePolicies.h:11:
/home/github/o3de/Code/Framework/AzCore/./AzCore/EBus/Policies.h:431:23: error: no matching function for call to 'invoke'
            results = AZStd::invoke(AZStd::forward<Function>(func), AZStd::forward<Interface>(iface), AZStd::forward<InputArgs>(args)...);
                      ^~~~~~~~~~~~~
/home/github/o3de/Code/Framework/AzCore/./AzCore/EBus/Internal/BusContainer.h:1556:60: note: in instantiation of function template specialization 'AZ::EBusEventProcessingPolicy::CallResult<AZStd::shared_ptr<AZ::SceneAPI::Containers::Scene>, AZStd::shared_ptr<AZ::SceneAPI::Containers::Scene> (AZ::SceneAPI::Events::SceneSerialization::*)(const AZStd::basic_string<char> &, AZ::Uuid, const AZStd::basic_string<char> &), AZ::SceneAPI::Events::SceneSerialization *&, const char *, AZ::Uuid>' requested here
                            Traits::EventProcessingPolicy::CallResult(results, AZStd::forward<Function>(func), handler, AZStd::forward<ArgsT>(args)...);
                                                           ^
/home/github/o3de-ros2-gem/Code/Source/RobotImporter/URDF/CollidersMaker.cpp:180:58: note: in instantiation of function template specialization 'AZ::Internal::EBusContainer<AZ::SceneAPI::Events::SceneSerialization, AZ::SceneAPI::Events::SceneSerialization, AZ::EBusAddressPolicy::Single, AZ::EBusHandlerPolicy::Single>::Dispatcher<AZ::EBus<AZ::SceneAPI::Events::SceneSerialization>>::BroadcastResult<AZStd::shared_ptr<AZ::SceneAPI::Containers::Scene>, AZStd::shared_ptr<AZ::SceneAPI::Containers::Scene> (AZ::SceneAPI::Events::SceneSerialization::*)(const AZStd::basic_string<char> &, AZ::Uuid, const AZStd::basic_string<char> &), const char *, AZ::Uuid>' requested here
            AZ::SceneAPI::Events::SceneSerializationBus::BroadcastResult(
                                                         ^
/home/github/o3de/Code/Framework/AzCore/./AzCore/std/function/invoke.h:52:50: note: candidate template ignored: substitution failure [with F = AZStd::shared_ptr<AZ::SceneAPI::Containers::Scene> (AZ::SceneAPI::Events::SceneSerialization::*)(const AZStd::basic_string<char> &, AZ::Uuid, const AZStd::basic_string<char> &), Args = <AZ::SceneAPI::Events::SceneSerialization *&, const char *, AZ::Uuid>]: no type named 'type' in 'AZStd::invoke_result<AZStd::shared_ptr<AZ::SceneAPI::Containers::Scene> (AZ::SceneAPI::Events::SceneSerialization::*)(const AZStd::basic_string<char> &, AZ::Uuid, const AZStd::basic_string<char> &), AZ::SceneAPI::Events::SceneSerialization *&, const char *, AZ::Uuid>'
    inline constexpr invoke_result_t<F, Args...> invoke(F&& f, Args&&... args)
                                                 ^
2 errors generated.
[5/397] Linking CXX static library lib/profile/libScriptCanvas.Static.a
ninja: build stopped: subcommand failed.

```
