### PR TITLE
Introduce a second check for URDF asset discovery.

### DIFF
--- a/Code/Source/RobotImporter/Utils/SourceAssetsStorage.cpp
+++ b/Code/Source/RobotImporter/Utils/SourceAssetsStorage.cpp
@@ -32,7 +32,7 @@ namespace ROS2::Utils
 
     AZStd::unordered_map<AZ::Crc32, AvailableAsset> GetInterestingSourceAssetsCRC()
     {
-        const AZStd::unordered_set<AZStd::string> kInterestingExtensions{ ".dae", ".stl", ".obj" };
+        const AZStd::unordered_set<AZStd::string> kInterestingExtensions{ ".dae", ".stl", ".obj", ".fbx" };
         const AZStd::string kAzModelExtension(".azmodel");
         AZStd::unordered_map<AZ::Crc32, AvailableAsset> availableAssets;
 

--- a/Code/Source/RobotImporter/Utils/SourceAssetsStorage.cpp
+++ b/Code/Source/RobotImporter/Utils/SourceAssetsStorage.cpp
@@ -33,6 +33,7 @@ namespace ROS2::Utils
     AZStd::unordered_map<AZ::Crc32, AvailableAsset> GetInterestingSourceAssetsCRC()
     {
         const AZStd::unordered_set<AZStd::string> kInterestingExtensions{ ".dae", ".stl", ".obj" };
+        const AZStd::string kAzModelExtension(".azmodel");
         AZStd::unordered_map<AZ::Crc32, AvailableAsset> availableAssets;
 
         // take all meshes in catalog
@@ -77,7 +78,20 @@ namespace ROS2::Utils
                 t.m_assetId = info.m_assetId;
                 t.m_sourceAssetGlobalPath = fullSourcePathStr;
                 t.m_productAssetRelativePath = info.m_relativePath;
-                availableAssets[crc] = t;
+
+                if (availableAssets.contains(crc))
+                {
+                    const AZStd::string stem(fullSourcePath.Stem().Native());
+                    // probably there is already submesh added. Replace only if there is exact name
+                    if (info.m_relativePath.contains(stem + kAzModelExtension))
+                    {
+                        availableAssets[crc] = t;
+                    }
+                }
+                else
+                {
+                    availableAssets[crc] = t;
+                }
             }
         };
         AZ::Data::AssetCatalogRequestBus::Broadcast(


### PR DESCRIPTION
It prevents choosing sub-mesh in a situation when the Asset processor has created more than one product asset from the source asset.

Signed-off-by: Michał Pełka <michal.pelka@robotec.ai>