### PR TITLE
Adjust ROS2 Gem's code to recent changes in O3DE.

### DIFF
--- a/.github/workflows/Build.yml
+++ b/.github/workflows/Build.yml
@@ -20,7 +20,7 @@ jobs:
     timeout-minutes: 60
     env:
 #     vv Change the o3de hash (LONG FORMAT!) here to fit the build vv
-      O3DE_SHA: 932a0327a58580028bb4a314b2d464dd974edaef
+      O3DE_SHA: f12e0b8f8a5be06027bca4c000c20b15f552c2cc
       ROS_DISTRO: galactic
     steps:
       - name: O3DE ROS 2 Gem checkout

--- a/Code/Source/RobotImporter/URDF/JointsMaker.cpp
+++ b/Code/Source/RobotImporter/URDF/JointsMaker.cpp
@@ -60,13 +60,13 @@ namespace ROS2
                 PhysX::EditorJointRequestBus::Event(
                     AZ::EntityComponentIdPair(followColliderEntityId, jointComponent->GetId()),
                     &PhysX::EditorJointRequests::SetVector3Value,
-                    PhysX::JointsComponentModeCommon::ParamaterNames::Rotation,
+                    PhysX::JointsComponentModeCommon::ParameterNames::Rotation,
                     rotation);
 
                 PhysX::EditorJointRequestBus::Event(
                     AZ::EntityComponentIdPair(followColliderEntityId, jointComponent->GetId()),
                     &PhysX::EditorJointRequests::SetLinearValuePair,
-                    PhysX::JointsComponentModeCommon::ParamaterNames::LinearLimits,
+                    PhysX::JointsComponentModeCommon::ParameterNames::LinearLimits,
                     PhysX::AngleLimitsFloatPair(joint->limits->upper, joint->limits->lower));
 
                 followColliderEntity->Deactivate();
@@ -80,19 +80,19 @@ namespace ROS2
                 PhysX::EditorJointRequestBus::Event(
                     AZ::EntityComponentIdPair(followColliderEntityId, jointComponent->GetId()),
                     &PhysX::EditorJointRequests::SetVector3Value,
-                    PhysX::JointsComponentModeCommon::ParamaterNames::Rotation,
+                    PhysX::JointsComponentModeCommon::ParameterNames::Rotation,
                     rotation);
 
                 PhysX::EditorJointRequestBus::Event(
                     AZ::EntityComponentIdPair(followColliderEntityId, jointComponent->GetId()),
                     &PhysX::EditorJointRequests::SetLinearValuePair,
-                    PhysX::JointsComponentModeCommon::ParamaterNames::TwistLimits,
+                    PhysX::JointsComponentModeCommon::ParameterNames::TwistLimits,
                     PhysX::AngleLimitsFloatPair(AZ::RadToDeg(AZ::Constants::TwoPi), -AZ::RadToDeg(AZ::Constants::TwoPi)));
 
                 PhysX::EditorJointRequestBus::Event(
                     AZ::EntityComponentIdPair(followColliderEntityId, jointComponent->GetId()),
                     &PhysX::EditorJointRequests::SetBoolValue,
-                    PhysX::JointsComponentModeCommon::ParamaterNames::EnableLimits,
+                    PhysX::JointsComponentModeCommon::ParameterNames::EnableLimits,
                     false);
 
                 followColliderEntity->Deactivate();
@@ -115,13 +115,13 @@ namespace ROS2
                 PhysX::EditorJointRequestBus::Event(
                     AZ::EntityComponentIdPair(followColliderEntityId, jointComponent->GetId()),
                     &PhysX::EditorJointRequests::SetVector3Value,
-                    PhysX::JointsComponentModeCommon::ParamaterNames::Rotation,
+                    PhysX::JointsComponentModeCommon::ParameterNames::Rotation,
                     rotation);
 
                 PhysX::EditorJointRequestBus::Event(
                     AZ::EntityComponentIdPair(followColliderEntityId, jointComponent->GetId()),
                     &PhysX::EditorJointRequests::SetLinearValuePair,
-                    PhysX::JointsComponentModeCommon::ParamaterNames::TwistLimits,
+                    PhysX::JointsComponentModeCommon::ParameterNames::TwistLimits,
                     PhysX::AngleLimitsFloatPair(limitUpper, limitLower));
 
                 followColliderEntity->Deactivate();
@@ -136,7 +136,7 @@ namespace ROS2
         PhysX::EditorJointRequestBus::Event(
             AZ::EntityComponentIdPair(followColliderEntityId, jointComponent->GetId()),
             &PhysX::EditorJointRequests::SetEntityIdValue,
-            PhysX::JointsComponentModeCommon::ParamaterNames::LeadEntity,
+            PhysX::JointsComponentModeCommon::ParameterNames::LeadEntity,
             leadColliderEntityId);
         followColliderEntity->Deactivate();
         return AZ::Success(jointComponent->GetId());


### PR DESCRIPTION
The development branch of O3DE was updated with typo fix that prevents ROS2 Gem to compile.

Signed-off-by: Michał Pełka <michal.pelka@robotec.ai>